### PR TITLE
Authors change; previous list looked daft in RubyGems GUI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    hoodoo (1.0.0)
+    hoodoo (1.0.1)
       dalli (~> 2.7)
       kgio (~> 2.9)
       uuidtools (~> 2.1)
@@ -56,7 +56,7 @@ GEM
     kgio (2.10.0)
     le (2.6.2)
     minitest (5.8.3)
-    msgpack (0.5.9)
+    msgpack (0.7.1)
     multi_json (1.11.2)
     multi_xml (0.5.5)
     pg (0.18.4)

--- a/hoodoo.gemspec
+++ b/hoodoo.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do | s |
   s.date        = '2016-12-10'
   s.summary     = 'Opinionated APIs'
   s.description = 'Simplify the implementation of consistent services within an API-based software platform.'
-  s.authors     = [ 'Tom Cully',               'Andrew Hodgkinson'               ]
-  s.email       = [ 'tom.cully@loyalty.co.nz', 'andrew.hodgkinson@loyalty.co.nz' ]
+  s.authors     = [ 'Loyalty New Zealand' ]
+  s.email       = [ 'andrew.hodgkinson@loyalty.co.nz' ]
   s.license     = 'LGPL-3.0'
 
   s.files       = Dir.glob( 'lib/**/*.rb' )

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -11,6 +11,6 @@ module Hoodoo
 
   # The Hoodoo gem version.
   #
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 
 end


### PR DESCRIPTION
 Since 1.0.0 was pushed, 1.0.1 must be produced; 1.0.0 yanked from RubyGems for good measure.