### PR TITLE
Feature/manually dated

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,6 @@ PATH
     hoodoo (1.1.3)
       dalli (~> 2.7)
       kgio (~> 2.9)
-      uuidtools (~> 2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/hoodoo.gemspec
+++ b/hoodoo.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do | s |
 
   s.required_ruby_version = '>= 2.1'
 
-  s.add_runtime_dependency     'uuidtools',        '~> 2.1'
   s.add_runtime_dependency     'kgio',             '~> 2.9' # Speeds up Dalli
   s.add_runtime_dependency     'dalli',            '~> 2.7' # Memcached client
 

--- a/lib/hoodoo/active.rb
+++ b/lib/hoodoo/active.rb
@@ -22,6 +22,7 @@ require 'hoodoo/active/active_record/error_mapping'
 
 require 'hoodoo/active/active_record/secure'
 require 'hoodoo/active/active_record/dated'
+require 'hoodoo/active/active_record/manually_dated'
 require 'hoodoo/active/active_record/translated'
 require 'hoodoo/active/active_record/finder'
 

--- a/lib/hoodoo/active/active_record/base.rb
+++ b/lib/hoodoo/active/active_record/base.rb
@@ -22,6 +22,7 @@ module Hoodoo
       #
       # * Hoodoo::ActiveRecord::Secure
       # * Hoodoo::ActiveRecord::Dated
+      # * Hoodoo::ActiveRecord::ManuallyDated
       # * Hoodoo::ActiveRecord::Translated
       # * Hoodoo::ActiveRecord::Finder
       # * Hoodoo::ActiveRecord::UUID
@@ -29,12 +30,17 @@ module Hoodoo
       # * Hoodoo::ActiveRecord::Writer
       # * Hoodoo::ActiveRecord::ErrorMapping
       #
+      # ...but not necessarily _activate_ those modules. For example,
+      # the Hoodoo::ActiveRecord::Dated module must be activated by a
+      # call to Hoodoo::ActiveRecord::Dated.dating_enabled.
+      #
       class Base < ::ActiveRecord::Base
 
         # Reading data.
         #
         include Hoodoo::ActiveRecord::Secure
         include Hoodoo::ActiveRecord::Dated
+        include Hoodoo::ActiveRecord::ManuallyDated
         include Hoodoo::ActiveRecord::Translated
         include Hoodoo::ActiveRecord::Finder
 
@@ -62,6 +68,7 @@ module Hoodoo
 
           Hoodoo::ActiveRecord::Secure.instantiate( model )
           Hoodoo::ActiveRecord::Dated.instantiate( model )
+          Hoodoo::ActiveRecord::ManuallyDated.instantiate( model )
           Hoodoo::ActiveRecord::Translated.instantiate( model )
           Hoodoo::ActiveRecord::Finder.instantiate( model )
 

--- a/lib/hoodoo/active/active_record/creator.rb
+++ b/lib/hoodoo/active/active_record/creator.rb
@@ -38,7 +38,7 @@ module Hoodoo
     #
     module Creator
 
-      # Instantiates this module when it is included:
+      # Instantiates this module when it is included.
       #
       # Example:
       #

--- a/lib/hoodoo/active/active_record/dated.rb
+++ b/lib/hoodoo/active/active_record/dated.rb
@@ -108,7 +108,7 @@ module Hoodoo
     #
     module Dated
 
-      # Instantiates this module when it is included:
+      # Instantiates this module when it is included.
       #
       # Example:
       #

--- a/lib/hoodoo/active/active_record/dated.rb
+++ b/lib/hoodoo/active/active_record/dated.rb
@@ -179,6 +179,13 @@ module Hoodoo
 
         end
 
+        # If a prior call has been made to #dating_enabled then this method
+        # returns +true+, else +false+.
+        #
+        def dating_enabled?
+          return self.dated_with() != nil?
+        end
+
         # Return an ActiveRecord::Relation containing the model instances which
         # are effective at +context.request.dated_at+. If this value is nil the
         # current time in UTC is used.

--- a/lib/hoodoo/active/active_record/finder.rb
+++ b/lib/hoodoo/active/active_record/finder.rb
@@ -35,7 +35,7 @@ module Hoodoo
     #
     module Finder
 
-      # Instantiates this module when it is included:
+      # Instantiates this module when it is included.
       #
       # Example:
       #
@@ -43,6 +43,8 @@ module Hoodoo
       #       include Hoodoo::ActiveRecord::Finder
       #       # ...
       #     end
+      #
+      # Depends upon and auto-includes Hoodoo::ActiveRecord::Secure.
       #
       # +model+:: The ActiveRecord::Base descendant that is including
       #           this module.

--- a/lib/hoodoo/active/active_record/finder.rb
+++ b/lib/hoodoo/active/active_record/finder.rb
@@ -52,6 +52,7 @@ module Hoodoo
       def self.included( model )
         model.class_attribute(
           :nz_co_loyalty_hoodoo_show_id_fields,
+          :nz_co_loyalty_hoodoo_show_id_substitute,
           :nz_co_loyalty_hoodoo_search_with,
           :nz_co_loyalty_hoodoo_filter_with,
           {
@@ -239,6 +240,7 @@ module Hoodoo
         # *args:: One or more field names as Strings or Symbols.
         #
         # See also: #acquired_with
+        #           #acquire_with_id_substitute
         #
         def acquire_with( *args )
           self.nz_co_loyalty_hoodoo_show_id_fields = args.map( & :to_s )
@@ -251,15 +253,44 @@ module Hoodoo
         # values only.
         #
         # See also: #acquire_with
+        #           #acquire_with_id_substitute
         #
         def acquired_with
           self.nz_co_loyalty_hoodoo_show_id_fields || []
+        end
+
+        # The #acquire_with method allows methods like #acquire and
+        # #acquire_in to transparently find a record based on _one_ _or_
+        # _more_ columns in the database. The columns (and corresponding
+        # model attributes) specified through a call to #acquire_with will
+        # normally be used _in_ _addition_ _to_ a lookup on the +id+
+        # column, but in rare circumstances you might need to bypass that
+        # and use an entirely different field. This is distinct from the
+        # ActiveRecord-level concept of the model's primary key column.
+        #
+        # To permanently change the use of the +id+ attribute as the first
+        # search parameter in #acquire and #acquire_in, by modifying the
+        # behaviour of #acquisition_scope, call here and pass in the new
+        # attribute name.
+        #
+        # +attr+:: Attribute name as a Symbol or String to use _instead_
+        #          of +id+, as a default mandatory column in
+        #          #acquisition_scope.
+        #
+        def acquire_with_id_substitute( attr )
+          self.nz_co_loyalty_hoodoo_show_id_substitute = attr.to_sym
         end
 
         # Back-end to #acquire and therefore, in turn, #acquire_in. Returns
         # an ActiveRecord::Relation instance which scopes the search for a
         # record by +id+ and across any other columns specified by
         # #acquire_with, via SQL +OR+.
+        #
+        # If you need to change the use of attribute +id+, specify a
+        # different attribute with #acquire_with_id_substitute. In that case,
+        # the given attribute is searched for instead of +id+; either way, a
+        # default starting attribute _will_ be used in scope in addition to
+        # any extra fields specified using #acquire_with.
         #
         # Normally such a scope could only ever return a single record based
         # on an assuption of uniqueness constraints around columns which one
@@ -272,7 +303,7 @@ module Hoodoo
         def acquisition_scope( ident )
           extra_fields = self.acquired_with()
           arel_table   = self.arel_table()
-          arel_query   = arel_table[ :id ].eq( ident )
+          arel_query   = arel_table[ self.nz_co_loyalty_hoodoo_show_id_substitute || :id ].eq( ident )
 
           extra_fields.each do | field |
             arel_query = arel_query.or( arel_table[ field ].eq( ident ) )

--- a/lib/hoodoo/active/active_record/finder.rb
+++ b/lib/hoodoo/active/active_record/finder.rb
@@ -239,7 +239,8 @@ module Hoodoo
         # See also: #acquired_with
         #
         def acquire_with( *args )
-          self.nz_co_loyalty_hoodoo_show_id_fields = args.map( & :to_s ).uniq!()
+          self.nz_co_loyalty_hoodoo_show_id_fields = args.map( & :to_s )
+          self.nz_co_loyalty_hoodoo_show_id_fields.uniq!()
         end
 
         # Return the list of model fields _in_ _addition_ _to_ +id+ which

--- a/lib/hoodoo/active/active_record/manually_dated.rb
+++ b/lib/hoodoo/active/active_record/manually_dated.rb
@@ -1,0 +1,330 @@
+########################################################################
+# File::    manually_dated.rb
+# (C)::     Loyalty New Zealand 2015
+#
+# Purpose:: Support mixin for models subclassed from ActiveRecord::Base
+#           providing as-per-API-standard dating support.
+# ----------------------------------------------------------------------
+#           14-Jul-2015 (ADH): Created.
+#           21-Jul-2015 (RJS): Functionality implemented.
+########################################################################
+
+module Hoodoo
+  module ActiveRecord
+
+    # Support mixin for models subclassed from ActiveRecord::Base providing
+    # as-per-API-standard dating support with services needing to know that
+    # dating is enabled and cooperate with this mixin's API, rather than
+    # working automatically via database triggers as per
+    # Hoodoo::ActiveRecord::Dated. The latter is close to transparent for
+    # ActiveRecord-based code, but it involves very complex database queries
+    # that can have high cost and is tied into PostgreSQL.
+    #
+    module ManuallyDated
+
+      # Instantiates this module when it is included:
+      #
+      # Example:
+      #
+      #     class SomeModel < ActiveRecord::Base
+      #       include Hoodoo::ActiveRecord::ManuallyDated
+      #       # ...
+      #     end
+      #
+      # +model+:: The ActiveRecord::Base descendant that is including
+      #           this module.
+      #
+      def self.included( model )
+        model.class_attribute(
+          :nz_co_loyalty_hoodoo_manually_dated,
+          {
+            :instance_predicate => false,
+            :instance_accessor  => false
+          }
+        )
+
+        instantiate( model ) unless model == Hoodoo::ActiveRecord::Base
+        super( model )
+      end
+
+      # When instantiated in an ActiveRecord::Base subclass, all of the
+      # Hoodoo::ActiveRecord::ManullyDated::ClassMethods methods are defined
+      # as class methods on the including class.
+      #
+      # +model+:: The ActiveRecord::Base descendant that is including
+      #           this module.
+      #
+      def self.instantiate( model )
+        model.extend( ClassMethods )
+      end
+
+      # Collection of class methods that get defined on an including class via
+      # Hoodoo::ActiveRecord::ManuallyDated::included.
+      #
+      module ClassMethods
+
+        # Activate manually-driven historic dating for this model.
+        #
+        # See the module documentation for Hoodoo::ActiveRecord::ManuallyDated
+        # for full information on dating, column/attribute requirements and so
+        # forth.
+        #
+        # When dating is enabled, a +before_save+ filter will ensure that the
+        # record's +created_at+ and +updated_at+ fields are manually set to the
+        # current time ("now"), _if_ not already set by the time the filter is
+        # run. The record's +effective_start+ time is set to match +created_at+
+        # _if_ not already set. The record's +primary_id+ primary key is set to
+        # the value of +id+ concatenated by a new secondary UUID to form a 64
+        # character unique value, again _if_ this is not already set.
+        #
+        def manual_dating_enabled
+          self.nz_co_loyalty_hoodoo_manually_dated = true
+
+          before_save do
+            now = Time.now.utc
+
+            self.created_at      ||= now
+            self.updated_at      ||= now
+            self.effective_start ||= self.created_at
+            self.primary_id      ||= "#{ self.id }#{ Hoodoo::UUID.generate() }"
+          end
+        end
+
+        # If a prior call has been made to #manual_dating_enabled then this
+        # method returns +true+, else +false+.
+        #
+        def manual_dating_enabled?
+          return self.nz_co_loyalty_hoodoo_manually_dated == true
+        end
+
+        # Return an ActiveRecord::Relation instance which only matches records
+        # that are relevant/effective at the date/time in the value of
+        # +context.request.dated_at+ within the given +context+. If this value
+        # is +nil+ then the current time in UTC is used.
+        #
+        # Manual historic dating must have been previously activated through a
+        # call to #dating_enabled, else results will be undefined.
+        #
+        # +context+:: Hoodoo::Services::Context instance describing a call
+        #             context. This is typically a value passed to one of
+        #             the Hoodoo::Services::Implementation instance methods
+        #             that a resource subclass implements.
+        #
+        def manually_dated( context )
+          date_time = context.request.dated_at || Time.now.utc
+          return self.manually_dated_at( date_time )
+        end
+
+        # Return an ActiveRecord::Relation instance which only matches records
+        # that are relevant/effective at the given date/time. If this value is
+        # +nil+ then the current time in UTC is used.
+        #
+        # Manual historic dating must have been previously activated through a
+        # call to #dating_enabled, else results will be undefined.
+        #
+        # +date_time+:: (Optional) A Time or DateTime instance, or a String that
+        #               can be converted to a DateTime instance, for which the
+        #               "effective dated" scope is to be constructed.
+        #
+        def manually_dated_at( date_time = Time.now.utc )
+          date_time  = Hoodoo::Utilities.nanosecond_iso8601( date_time.utc )
+          arel_table = self.arel_table()
+          arel_query = arel_table[ :effective_start ].lteq( date_time ).
+                       and(
+                         arel_table[ :effective_end ].gt( date_time ).
+                         or(
+                           arel_table[ :effective_end ].eq( nil )
+                         )
+                       )
+
+          where( arel_query )
+        end
+
+        # Return an ActiveRecord::Relation instance which only matches records
+        # that are from the past. The 'current' record for any given UUID will
+        # never be included by the scope.
+        #
+        # Manual historic dating must have been previously activated through a
+        # call to #dating_enabled, else results will be undefined.
+        #
+        def manually_dated_historic
+          where.not( :effective_end => nil )
+        end
+
+        # Return an ActiveRecord::Relation instance which only matches records
+        # that are 'current'. The historic/past records for any given UUID
+        # will never be included in the scope.
+        #
+        # Manual historic dating must have been previously activated through a
+        # call to #dating_enabled, else results will be undefined.
+        #
+        def manually_dated_contemporary
+          where( :effective_end => nil )
+        end
+
+        # Update a record with manual historic dating. This means that the
+        # 'current' / most recent record is turned into a historic entry via
+        # setting its +effective_end+ date, a duplicate is made and any new
+        # attribute values are set in this duplicate. This new record is then
+        # saved as the 'current' version. A transaction containing a database
+        # lock over all history rows for the record via its UUID (+id+ column)
+        # is used to provide concurrent access safety.
+        #
+        # The return value is complex:
+        #
+        # * If +nil+, the record that was to be updated could not be found.
+        # * If not +nil+, an ActiveRecord model instance is returned. This is
+        #   the new 'current' record, but it might not be saved; validation
+        #   errors may have happened. You need to check for this before
+        #   proceeding. This will _not_ be the same model instance found for
+        #   the original, most recent / current record.
+        #
+        # If attempts to update the previous, now-historic record's effective
+        # end date fail, an exception may be thrown as the failure condition
+        # is unexpected (it will almost certainly be because of a database
+        # connection failure). You _might_ need to call this method from a
+        # block with a +rescue+ clause if you wish to handle those elegantly,
+        # but it is probably a serious failure and the generally recommended
+        # behaviour is to just let Hoodoo's default exception handler catch
+        # the exception and return an HTTP 500 response to the API caller.
+        #
+        # _Unnamed_ parameters are:
+        #
+        # +context+::    Hoodoo::Services::Context instance describing a call
+        #                context. This is typically a value passed to one of
+        #                the Hoodoo::Services::Implementation instance methods
+        #                that a resource subclass implements. This is used to
+        #                find the record's UUID and new attribute information
+        #                unless overridden (see named parameter list).
+        #
+        # Additional _named_ parameters are:
+        #
+        # +ident+::      UUID (32-digit +id+ column value) of the record to be
+        #                updated. If omitted, +context.request.ident+ is used.
+        #
+        # +attributes+:: Hash of attributes to write (via ActiveRecord's
+        #                +assign_attributes+ method) in order to perform the
+        #                update. If omitted, +context.request.body+ is used.
+        #
+        # +scope+::      ActiveRecord::Relation instance providing the scope
+        #                to use for database locks and acquiring the record
+        #                to update. Defaults to #acquisition_scope for the
+        #                prevailing +ident+ value.
+        #
+        def manually_dated_update_in( context,
+                                      ident:      context.request.ident,
+                                      attributes: context.request.body,
+                                      scope:      self.acquisition_scope( ident ) )
+
+          return self.transaction do
+
+            locked_rows = scope.lock()
+            original    = scope.manually_dated_contemporary().acquire( ident )
+
+            break if original.nil?
+
+            # Set the end date on the "newest" record to mark it as a historic
+            # entry. We never expect this to fail; if it did, an exception is
+            # likely even without the "!" form of the method, but use this
+            # explicitly and document clearly that an exception may arise.
+            #
+            original.effective_end = Time.now.utc
+            original.save!
+
+            # When you 'dup' a live model, ActiveRecord clears the 'created_at'
+            # and 'updated_at' values, and the 'id' column - even if you set
+            # the "primary_key=..." value on the model to something else. Put
+            # it all back together again.
+            #
+            # Duplicate, apply attributes, then overwrite anything that is
+            # vital for dating so that the inbound attributes hash can't cause
+            # any inconsistencies.
+            #
+            updated = original.dup
+            updated.assign_attributes( attributes )
+
+            updated.id              = original.id
+            updated.created_at      = original.created_at
+            updated.updated_at      = original.effective_end # (sic.)
+            updated.effective_start = original.effective_end # (sic.)
+            updated.effective_end   = nil
+
+            # Let the before_save filter create the primary ID (the real
+            # primary key, as far as the database goes).
+            #
+            updated.primary_id = nil
+
+            # This time, save with validation but no exceptions. The caller
+            # examines the returned object to see if there are validation
+            # errors / no persistence.
+            #
+            updated.save
+
+            # The evaluated result of the transaction block must be 'updated'
+            # in order for the method's return value to be as documented.
+            #
+            updated
+
+          end
+        end
+
+        # Analogous to #manually_dated_update_in and with the same return
+        # value and exception generation semantics, so see that method for
+        # those details.
+        #
+        # This particular method soft-deletes a record. It moves the 'current'
+        # entry to being an 'historic' entry as in #manually_dated_update_in,
+        # but does not then generate any new 'current' record. Returns +nil+
+        # if the record couldn't be found to start with, else returns the
+        # found and soft-deleted / now-historic model instance.
+        #
+        # Since no actual "hard" record deletion takes place, traditional
+        # ActiveRecord concerns of +delete+ versus +destroy+ or of dependency
+        # chain destruction do not apply. Callbacks related to _updating_
+        # will be triggered, bceause that's the only thing happening "under
+        # the hood".
+        #
+        # _Unnamed_ parameters are:
+        #
+        # +context+::    Hoodoo::Services::Context instance describing a call
+        #                context. This is typically a value passed to one of
+        #                the Hoodoo::Services::Implementation instance methods
+        #                that a resource subclass implements. This is used to
+        #                obtain the record's UUID unless overridden (see named
+        #                parameter list).
+        #
+        # Additional _named_ parameters are:
+        #
+        # +ident+::      UUID (32-digit +id+ column value) of the record to be
+        #                updated. If omitted, +context.request.ident+ is used.
+        #
+        # +scope+::      ActiveRecord::Relation instance providing the scope
+        #                to use for database locks and acquiring the record
+        #                to update. Defaults to #acquisition_scope for the
+        #                prevailing +ident+ value.
+        #
+        def manually_dated_destruction_in( context,
+                                           ident: context.request.ident,
+                                           scope: self.acquisition_scope( ident ) )
+
+          # See #manually_dated_update_in for rationale.
+          #
+          return self.transaction do
+
+            locked_rows = scope.lock()
+            record      = scope.manually_dated_contemporary().acquire( ident )
+
+            break if record.nil?
+
+            record.effective_end = Time.now.utc
+            record.save!
+
+            record
+
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/lib/hoodoo/active/active_record/secure.rb
+++ b/lib/hoodoo/active/active_record/secure.rb
@@ -22,7 +22,7 @@ module Hoodoo
     #
     module Secure
 
-      # Instantiates this module when it is included:
+      # Instantiates this module when it is included.
       #
       # Example:
       #

--- a/lib/hoodoo/active/active_record/support.rb
+++ b/lib/hoodoo/active/active_record/support.rb
@@ -64,7 +64,9 @@ module Hoodoo
       #
       # * Hoodoo::ActiveRecord::Secure#secure
       # * Hoodoo::ActiveRecord::Translated#translated
-      # * Hoodoo::ActiveRecord::Dated#dated
+      # * Hoodoo::ActiveRecord::Dated#dated (if "dating_enabled?" is +true+)
+      # * Hoodoo::ActiveRecord::ManuallyDated#manually_dated
+      #   (if "manual_dating_enabled?" is +true+)
       #
       # +klass+::   The ActiveRecord::Base subclass _class_ (not instance)
       #             which is making the call here. This is the entity which is
@@ -86,8 +88,12 @@ module Hoodoo
         # Due to the mechanism used, dating scope must be done first or the
         # rest of the query may be invalid.
         #
-        if klass.include?( Hoodoo::ActiveRecord::Dated )
+        if klass.include?( Hoodoo::ActiveRecord::Dated ) && klass.dating_enabled?()
           prevailing_scope = prevailing_scope.dated( context )
+        end
+
+        if klass.include?( Hoodoo::ActiveRecord::ManuallyDated ) && klass.manual_dating_enabled?()
+          prevailing_scope = prevailing_scope.manually_dated( context )
         end
 
         if klass.include?( Hoodoo::ActiveRecord::Secure )

--- a/lib/hoodoo/active/active_record/translated.rb
+++ b/lib/hoodoo/active/active_record/translated.rb
@@ -21,7 +21,7 @@ module Hoodoo
     #
     module Translated
 
-      # Instantiates this module when it is included:
+      # Instantiates this module when it is included.
       #
       # Example:
       #

--- a/lib/hoodoo/active/active_record/uuid.rb
+++ b/lib/hoodoo/active/active_record/uuid.rb
@@ -29,7 +29,7 @@ module Hoodoo
     #
     module UUID
 
-      # Instantiates this module when it is included:
+      # Instantiates this module when it is included.
       #
       # Example:
       #

--- a/lib/hoodoo/active/active_record/writer.rb
+++ b/lib/hoodoo/active/active_record/writer.rb
@@ -32,7 +32,7 @@ module Hoodoo
     #
     module Writer
 
-      # Instantiates this module when it is included:
+      # Instantiates this module when it is included.
       #
       # Example:
       #

--- a/lib/hoodoo/utilities/uuid.rb
+++ b/lib/hoodoo/utilities/uuid.rb
@@ -1,5 +1,3 @@
-require "uuidtools"
-
 module Hoodoo
 
   # Class that handles generation and validation of UUIDs. Whenever you
@@ -13,22 +11,30 @@ module Hoodoo
 
     # A regexp which, as its name suggests, only matches a string that
     # contains 16 pairs of hex digits (with upper or lower case A-F).
+    # Legacy value kept in case third party client code is using it.
     #
     # http://stackoverflow.com/questions/287684/regular-expression-to-validate-hex-string
     #
     MATCH_16_PAIRS_OF_HEX_DIGITS = /^([[:xdigit:]]{2}){16}$/
 
+    # A regexp which matches V4 UUIDs with hyphens removed. Note that
+    # this is more strict than MATCH_16_PAIRS_OF_HEX_DIGITS.
+    #
+    MATCH_V4_UUID = /^[a-fA-F0-9]{12}4[a-fA-F0-9]{3}[89aAbB][a-fA-F0-9]{15}$/
+
     # Generate a unique identifier. Returns a 32 character string.
     #
     def self.generate
-      UUIDTools::UUID.random_create().hexdigest()
+      SecureRandom.uuid().gsub!( '-', '' )
     end
 
     # Checks if a UUID string is valid. Returns +true+ if so, else +false+.
     #
-    # +uuid+:: UUID string to validate. Must be a String, 32 characters
-    #          long (as 16 hex digit pairs) and parse to a valid result
-    #          internally, according to internal UUID generation rules.
+    # +uuid+:: Quantity to validate.
+    #
+    # The method will only return +true+ if the input parameter is a String
+    # containing 32 mostly random hex digits representing a valid V4 UUID
+    # with hyphens removed.
     #
     # Note that the validity of a UUID says nothing about where, if anywhere,
     # it might have been used. So, just because a UUID is valid, doesn't mean
@@ -36,9 +42,7 @@ module Hoodoo
     # row in a database.
     #
     def self.valid?( uuid )
-      uuid.is_a?( ::String )                           &&
-      ( uuid =~ MATCH_16_PAIRS_OF_HEX_DIGITS ) != nil  &&
-      UUIDTools::UUID.parse_hexdigest( uuid ).valid?()
+      uuid.is_a?( ::String ) && ( uuid =~ MATCH_V4_UUID ) != nil
     end
   end
 end

--- a/spec/active/active_record/dated_spec.rb
+++ b/spec/active/active_record/dated_spec.rb
@@ -53,11 +53,13 @@ describe Hoodoo::ActiveRecord::Dated do
 
     before( :all ) do
 
-      # Create some examples data for finding. The data has two different UUIDs
+      # Create some example data for finding. The data has two different UUIDs
       # which I'll referer to as A and B. The following tables contain the
-      # historical and current records separately with their attributes.
+      # historical and current records separately with their attributes, with
+      # items created in the historical or main database tables respectively.
       #
       # Historical:
+      #
       # -------------------------------------------------------------------
       #  uuid | data    | created_at    | effective_end | effective_start |
       # -------------------------------------------------------------------
@@ -67,12 +69,12 @@ describe Hoodoo::ActiveRecord::Dated do
       #  B    | "four"  | now - 4 hours | now           | now - 2 hour    |
       #
       # Current:
+      #
       # --------------------------------
       #  uuid | data   | created_at    |
       # --------------------------------
       #  B    | "five" | now - 4 hours |
       #  A    | "six"  | now - 5 hours |
-      #
 
       @uuid_a = Hoodoo::UUID.generate
       @uuid_b = Hoodoo::UUID.generate
@@ -111,7 +113,23 @@ describe Hoodoo::ActiveRecord::Dated do
 
     end
 
-    context '.dated_at' do
+    context 'unscoped' do
+      it 'counts only the current records in the main database table' do
+        expect( model_klass.count ).to be 2
+      end
+
+      it 'finds only the current records in the main database table' do
+        expect( model_klass.pluck( :data ) ).to match_array( [ 'five', 'six' ] )
+      end
+    end
+
+    context '#dating_enabled?' do
+      it 'says it is automatically dated' do
+        expect( model_klass.dating_enabled? ).to eq( true )
+      end
+    end
+
+    context '#dated_at' do
       it 'returns counts correctly' do
         expect( model_klass.dated_at( @now - 10.hours ).count ).to be 0
         expect( model_klass.dated_at( @now ).count ).to be 2
@@ -143,7 +161,7 @@ describe Hoodoo::ActiveRecord::Dated do
 
     end
 
-    context '.dated' do
+    context '#dated' do
       it 'returns counts correctly' do
         # The contents of the Context are irrelevant aside from the fact that it
         # needs a request to store the dated_at value.
@@ -207,7 +225,7 @@ describe Hoodoo::ActiveRecord::Dated do
 
     end
 
-    context '.dated_historical_and_current' do
+    context '#dated_historical_and_current' do
       it 'returns counts correctly' do
         expect( model_klass.dated_historical_and_current.count ).to be 6
       end

--- a/spec/active/active_record/finder_spec.rb
+++ b/spec/active/active_record/finder_spec.rb
@@ -350,18 +350,40 @@ describe Hoodoo::ActiveRecord::Finder do
 
   # ==========================================================================
 
-  context 'acquisition_scope' do
-    it 'SQL generation is as expected' do
-      sql = RSpecModelFinderTest.acquisition_scope( @id ).to_sql()
+  context 'acquisition scope and overrides' do
+    def expect_sql( sql, id_attr_name )
       expect( sql ).to eq( "SELECT \"r_spec_model_finder_tests\".* "<<
                            "FROM \"r_spec_model_finder_tests\" " <<
                            "WHERE (" <<
                              "(" <<
-                               "\"r_spec_model_finder_tests\".\"id\" = '#{ @id }' OR " <<
+                               "\"r_spec_model_finder_tests\".\"#{ id_attr_name }\" = '#{ @id }' OR " <<
                                "\"r_spec_model_finder_tests\".\"uuid\" = '#{ @id }'" <<
                              ") OR " <<
                              "\"r_spec_model_finder_tests\".\"code\" = '#{ @id }'" <<
                            ")" )
+    end
+
+    context 'acquisition_scope' do
+      it 'SQL generation is as expected' do
+        sql = RSpecModelFinderTest.acquisition_scope( @id ).to_sql()
+        expect_sql( sql, 'id' )
+      end
+    end
+
+    context 'acquire_with_id_substitute' do
+      before :each do
+        @alt_attr_name = 'foo'
+        RSpecModelFinderTest.acquire_with_id_substitute( @alt_attr_name )
+      end
+
+      after :each do
+        RSpecModelFinderTest.acquire_with_id_substitute( 'id' )
+      end
+
+      it 'SQL generation is as expected' do
+        sql = RSpecModelFinderTest.acquisition_scope( @id ).to_sql()
+        expect_sql( sql, @alt_attr_name )
+      end
     end
   end
 

--- a/spec/active/active_record/manually_dated_spec.rb
+++ b/spec/active/active_record/manually_dated_spec.rb
@@ -1,0 +1,761 @@
+require 'spec_helper'
+require 'active_record'
+
+describe Hoodoo::ActiveRecord::ManuallyDated do
+
+  # ==========================================================================
+  # Data setup
+  # ==========================================================================
+
+  BAD_DATA_FOR_VALIDATIONS = 'bad_data'
+
+  before :all do
+    spec_helper_silence_stdout() do
+      ActiveRecord::Migration.create_table( :r_spec_model_manual_date_tests, :id => false ) do | t |
+        t.string :uuid, :null => false, :length => 32
+        t.string :id,   :null => false, :length => 32
+
+        t.text :data
+
+        t.timestamps
+        t.datetime :effective_start, :null => false
+        t.datetime :effective_end,   :null => true
+      end
+    end
+
+    class RSpecModelManualDateTest < ActiveRecord::Base
+      include Hoodoo::ActiveRecord::ManuallyDated
+      manual_dating_enabled()
+
+      validates_each :data do | record, attribute, value |
+        if value == BAD_DATA_FOR_VALIDATIONS
+          record.errors.add( attribute, 'contains bad text' )
+        end
+      end
+    end
+  end
+
+
+  # Create some example data for finding. The data has two different UUIDs
+  # which I'll referer to as A and B. The following tables list the
+  # historical and current records with their attributes. All are created
+  # as rows within the main test model class's one database table.
+  #
+  # The data is also seeded for any other tests, so that there's a known
+  # set of rows which can be examined for changes, or lack thereof.
+  #
+  # Historical:
+  #
+  # -------------------------------------------------------------------
+  #  uuid | data    | created_at    | effective_end | effective_start |
+  # -------------------------------------------------------------------
+  #  A    | 'one'   | now - 5 hours | now - 3 hours | now - 5 hours   |
+  #  B    | 'two'   | now - 4 hours | now - 2 hours | now - 4 hours   |
+  #  A    | 'three' | now - 5 hours | now - 1 hour  | now - 3 hours   |
+  #  B    | 'four'  | now - 4 hours | now           | now - 2 hour    |
+  #
+  # Current:
+  #
+  # -------------------------------------------------------------------
+  #  uuid | data    | created_at    | effective_end | effective_start |
+  # -------------------------------------------------------------------
+  #  B    | 'five'  | now - 4 hours | nil           | now - 5 hours   |
+  #  A    | 'six'   | now - 5 hours | nil           | now - 4 hours   |
+  #
+  before :each do
+
+    @now = Time.now.utc
+
+    @uuid_a = Hoodoo::UUID.generate
+    @uuid_b = Hoodoo::UUID.generate
+
+    # uuid, data, created_at, effective_end, effective_start
+    [
+      [ @uuid_a, 'one',   @now - 5.hours, @now - 3.hours, @now - 5.hours ],
+      [ @uuid_b, 'two',   @now - 4.hours, @now - 2.hours, @now - 4.hours ],
+      [ @uuid_a, 'three', @now - 5.hours, @now - 1.hour,  @now - 3.hours ],
+      [ @uuid_b, 'four',  @now - 4.hours, @now,           @now - 2.hours ],
+      [ @uuid_b, 'five',  @now - 4.hours, nil,            @now           ],
+      [ @uuid_a, 'six',   @now - 5.hours, nil,            @now - 1.hour  ]
+    ].each do | row_data |
+      RSpecModelManualDateTest.new( {
+        :id              => row_data[ 0 ],
+        :data            => row_data[ 1 ],
+        :created_at      => row_data[ 2 ],
+        :updated_at      => row_data[ 2 ],
+        :effective_end   => row_data[ 3 ],
+        :effective_start => row_data[ 4 ]
+      } ).save!
+    end
+
+    # This is a useful thing to have around! Just the bare minimum for the
+    # API under test. At the time of writing you can actually pass a "nil"
+    # context if all other attribute values are given, but that's not
+    # documented and besides, we want to test a mixture of context-based
+    # and explicitly specified parameters.
+    #
+    @context = Hoodoo::Services::Context.new( nil,
+                                              Hoodoo::Services::Request.new,
+                                              nil,
+                                              nil )
+  end
+
+  # ==========================================================================
+  # Reading tests
+  # ==========================================================================
+
+  context 'reading data' do
+    context 'unscoped' do
+      it 'counts all historical and current records in one database table' do
+        expect( RSpecModelManualDateTest.count ).to be 6
+      end
+
+      it 'finds all historical and current records in one database table' do
+        expect( RSpecModelManualDateTest.pluck( :data ) ).to match_array( [ 'one', 'two', 'three', 'four', 'five', 'six' ] )
+      end
+    end
+
+    context '#manual_dating_enabled?' do
+      it 'says it is manually dated' do
+        expect( RSpecModelManualDateTest.manual_dating_enabled? ).to eq( true )
+      end
+    end
+
+    context '#manually_dated_at' do
+      it 'returns counts correctly' do
+        expect( RSpecModelManualDateTest.manually_dated_at( @now - 10.hours ).count ).to be 0
+        expect( RSpecModelManualDateTest.manually_dated_at( @now ).count ).to be 2
+      end
+
+      def test_expectation( time, expected_data )
+        expect( RSpecModelManualDateTest.manually_dated_at( time ).pluck( :data ) ).to match_array( expected_data )
+      end
+
+      it 'returns no records before any were effective' do
+        test_expectation( @now - 10.hours, [] )
+      end
+
+      it 'returns records that used to be effective starting at past time' do
+        test_expectation( @now - 5.hours, [ 'one'           ] )
+        test_expectation( @now - 4.hours, [ 'one', 'two'    ] )
+        test_expectation( @now - 3.hours, [ 'two', 'three'  ] )
+        test_expectation( @now - 2.hours, [ 'three', 'four' ] )
+        test_expectation( @now - 1.hour,  [ 'four', 'six'   ] )
+      end
+
+      it 'returns records that are effective now' do
+        test_expectation( @now, [ 'five', 'six' ] )
+      end
+
+      it 'works with further filtering' do
+        expect( RSpecModelManualDateTest.manually_dated_at( @now ).where( :uuid => @uuid_a ).pluck( :data ) ).to eq( [ 'six' ] )
+      end
+
+    end
+
+    context '#manually_dated' do
+      it 'returns counts correctly' do
+        # The contents of the Context are irrelevant aside from the fact that it
+        # needs a request to store the dated_at value.
+        request = Hoodoo::Services::Request.new
+        context = Hoodoo::Services::Context.new( nil, request, nil, nil )
+
+        context.request.dated_at = @now - 10.hours
+        expect( RSpecModelManualDateTest.manually_dated( context ).count ).to be 0
+
+        context.request.dated_at = @now
+        expect( RSpecModelManualDateTest.manually_dated( context ).count ).to be 2
+      end
+
+      def test_expectation( time, expected_data )
+        # The contents of the Context are irrelevant aside from the fact that it
+        # needs a request to store the dated_at value.
+        request = Hoodoo::Services::Request.new
+        context = Hoodoo::Services::Context.new( nil, request, nil, nil )
+        context.request.dated_at = time
+
+        expect( RSpecModelManualDateTest.manually_dated( context ).pluck( :data ) ).to match_array( expected_data )
+      end
+
+      it 'returns no records before any were effective' do
+        test_expectation( @now - 10.hours, [] )
+      end
+
+      it 'returns records that used to be effective starting at past time' do
+        test_expectation( @now - 5.hours, [ 'one'           ] )
+        test_expectation( @now - 4.hours, [ 'one', 'two'    ] )
+        test_expectation( @now - 3.hours, [ 'two', 'three'  ] )
+        test_expectation( @now - 2.hours, [ 'three', 'four' ] )
+        test_expectation( @now - 1.hour,  [ 'four', 'six'   ] )
+      end
+
+      it 'returns records that are effective now' do
+        test_expectation( @now, [ 'five', 'six' ] )
+      end
+
+      it 'works with further filtering' do
+
+        # The contents of the Context are irrelevant aside from the fact that it
+        # needs a request to store the dated_at value.
+        request = Hoodoo::Services::Request.new
+        context = Hoodoo::Services::Context.new( nil, request, nil, nil )
+        context.request.dated_at = @now
+
+        expect( RSpecModelManualDateTest.manually_dated( context ).where( :uuid => @uuid_a ).pluck( :data ) ).to eq( [ 'six' ] )
+      end
+
+      it 'works with dating last' do
+
+        # The contents of the Context are irrelevant aside from the fact that it
+        # needs a request to store the dated_at value.
+        request = Hoodoo::Services::Request.new
+        context = Hoodoo::Services::Context.new( nil, request, nil, nil )
+        context.request.dated_at = @now
+
+        expect( RSpecModelManualDateTest.where( :uuid => @uuid_a ).manually_dated( context ).pluck( :data ) ).to eq( [ 'six' ] )
+      end
+    end
+
+    context '#manually_dated_historic' do
+      it 'counts only historic entries' do
+        expect( RSpecModelManualDateTest.manually_dated_historic.count ).to eq( 4 )
+      end
+
+      it 'finds only historic entries' do
+        expect( RSpecModelManualDateTest.manually_dated_historic.pluck( :data ) ).to match_array( [ 'one', 'two', 'three', 'four' ] )
+      end
+    end
+
+    context '#manually_dated_contemporary' do
+      it 'counts only contemporary entries' do
+        expect( RSpecModelManualDateTest.manually_dated_contemporary.count ).to eq( 2 )
+      end
+
+      it 'finds only contemporary entries' do
+        expect( RSpecModelManualDateTest.manually_dated_contemporary.pluck( :data ) ).to match_array( [ 'five', 'six' ] )
+      end
+    end
+  end
+
+  # ==========================================================================
+  # Writing tests
+  # ==========================================================================
+
+  context 'writing data' do
+    context '#manually_dated_update_in' do
+      before :each do
+        @change_data_from = Hoodoo::UUID.generate()
+        @change_data_to   = Hoodoo::UUID.generate()
+
+        @record = RSpecModelManualDateTest.new( {
+          :data       => @change_data_from,
+          :created_at => @now,
+          :updated_at => @now
+        } )
+
+        @record.save!
+
+        @context.request.instance_variable_set( '@ident', @record.uuid )
+        @context.request.body = { 'data' => @change_data_to }
+      end
+
+      # Call only for 'successful' update cases. Pass the result of a call to
+      # #manually_dated_update_in. Expects:
+      #
+      # * No new 'current' items
+      # * One new 'historic' item
+      # * Two unscoped things can now be found by @record's UUID
+      # * They should have the correct bounding dates and data.
+      #
+      # Remember that the very top of this file seeds in 2 contemporary and
+      # 4 historical entries, so counts are relative to that baseline.
+      #
+      def run_expectations( result )
+        expect( RSpecModelManualDateTest.manually_dated_contemporary.count ).to eq( 3 )
+        expect( RSpecModelManualDateTest.manually_dated_historic.count ).to eq( 5 )
+        expect( RSpecModelManualDateTest.manually_dated_contemporary.where( :uuid => @record.uuid ).count ).to eq( 1 )
+        expect( RSpecModelManualDateTest.manually_dated_historic.where( :uuid => @record.uuid ).count ).to eq( 1 )
+
+        # Current record is now at 'no'/nil time - i.e. actually Time.now. The
+        # time frozen into "@now" at the top of this file is by this point the
+        # historic time of the old record.
+
+        historic = RSpecModelManualDateTest.manually_dated_at( @now ).find_by_uuid( @record.uuid )
+        current  = RSpecModelManualDateTest.manually_dated_at().find_by_uuid( @record.uuid )
+
+        expect( result.uuid ).to eq( current.uuid )
+
+        expect( historic.data ).to eq( @change_data_from )
+        expect( current.data  ).to eq( @change_data_to   )
+
+        expect( historic.effective_end ).to eq( current.effective_start )
+        expect( historic.effective_end ).to eq( current.updated_at      )
+        expect( current.effective_end  ).to be_nil
+      end
+
+      it 'via context alone' do
+        result = RSpecModelManualDateTest.manually_dated_update_in(
+          @context
+        )
+
+        run_expectations( result )
+      end
+
+      # Generate a random => invalid UUID in the request data to prove that
+      # the valid one given in the input parameter is used as an override.
+      #
+      it 'specifying "ident"' do
+        @context.request.instance_variable_set( '@ident', Hoodoo::UUID.generate() )
+
+        result = RSpecModelManualDateTest.manually_dated_update_in(
+          @context,
+          ident: @record.uuid
+        )
+
+        run_expectations( result )
+      end
+
+      # Generate a random => invalid payload in the request data to prove that
+      # the valid one given in the input parameter is used as an override.
+      #
+      it 'specifying "attributes"' do
+        @context.request.body = { Hoodoo::UUID.generate() => 42 }
+
+        result = RSpecModelManualDateTest.manually_dated_update_in(
+          @context,
+          attributes: { 'data' => @change_data_to }
+        )
+
+        run_expectations( result )
+      end
+
+      it 'uses a given scope' do
+
+        # We expect the custom scope to be customised to find an
+        # acquisition scope for locking, if it's being used OK.
+        # This is fragile; depends heavily on implementation.
+
+        custom_scope = RSpecModelManualDateTest.where( :data => [ 'one', 'two', 'three' ] + [ @change_data_from ] )
+        expect( custom_scope ).to receive( :acquisition_scope ).and_call_original
+
+        result = RSpecModelManualDateTest.manually_dated_update_in(
+          @context,
+          scope: custom_scope
+        )
+
+        run_expectations( result )
+      end
+
+      context 'handles not-found' do
+        it 'because of a bad identifier' do
+          result = RSpecModelManualDateTest.manually_dated_update_in(
+            @context,
+            ident: Hoodoo::UUID.generate() # Random => invalid
+          )
+
+          expect( result ).to be_nil
+        end
+
+        it 'because of a scope' do
+          result = RSpecModelManualDateTest.manually_dated_update_in(
+            @context,
+            scope: RSpecModelManualDateTest.where( :data => [ Hoodoo::UUID.generate() ] ) # Random => invalid
+          )
+
+          expect( result ).to be_nil
+        end
+      end
+
+      context 'exceptions' do
+        def expect_correct_rollback( &block )
+          starting_original = RSpecModelManualDateTest.manually_dated_contemporary.acquire_in( @context )
+          expect( starting_original ).to_not be_nil # Self-check this test
+
+          yield( block )
+
+          ending_original = RSpecModelManualDateTest.manually_dated_contemporary.acquire_in( @context )
+
+          expect( ending_original ).to_not be_nil
+          expect( starting_original.attributes ).to eq( ending_original.attributes )
+        end
+
+        it 'handles validation errors and does not change the contemporary record' do
+          expect_correct_rollback do
+            result = nil
+
+            expect {
+              result = RSpecModelManualDateTest.manually_dated_update_in(
+                @context,
+                attributes: { 'data' => BAD_DATA_FOR_VALIDATIONS }
+              )
+            }.to_not change( RSpecModelManualDateTest, :count )
+
+            expect( result ).to_not be_nil
+            expect( result.persisted? ).to eq( false )
+            expect( result.errors.messages ).to eq( { :data => [ 'contains bad text' ] } )
+          end
+        end
+
+        it 'correctly rolls back in the face of unexpected exceptions' do
+          expect_correct_rollback do
+            expect_any_instance_of( RSpecModelManualDateTest ).to receive( :save ) {
+              raise 'stop'
+            }
+
+            expect {
+              expect {
+                RSpecModelManualDateTest.manually_dated_update_in(
+                  @context,
+                  attributes: { 'data' => Hoodoo::UUID.generate() }
+                )
+              }.to raise_exception( RuntimeError, 'stop' )
+            }.to_not change( RSpecModelManualDateTest, :count )
+          end
+        end
+
+        it 'retries after one deadlock' do
+          raised = false
+
+          allow_any_instance_of( RSpecModelManualDateTest ).to receive( :update_column ) do | instance, name, value |
+            if raised == false
+              raised = true
+              raise ::ActiveRecord::StatementInvalid.new( 'MOCK DEADLOCK EXCEPTION' )
+            else
+              instance.update_attribute( name, value )
+            end
+          end
+
+          result = nil
+
+          expect {
+            result = RSpecModelManualDateTest.manually_dated_update_in(
+              @context,
+              attributes: { 'data' => Hoodoo::UUID.generate() }
+            )
+          }.to change( RSpecModelManualDateTest, :count ).by( 1 )
+
+          expect( result ).to_not be_nil
+          expect( result.errors ).to be_empty
+          expect( result.persisted? ).to eq( true )
+        end
+
+        it 'gives up after two deadlocks' do
+          allow_any_instance_of( RSpecModelManualDateTest ).to receive( :update_column ) do | instance, name, value |
+            raise ::ActiveRecord::StatementInvalid.new( 'MOCK DEADLOCK EXCEPTION' )
+          end
+
+          expect_correct_rollback do
+            expect {
+              result = RSpecModelManualDateTest.manually_dated_update_in(
+                @context,
+                attributes: { 'data' => Hoodoo::UUID.generate() }
+              )
+            }.to raise_exception( ::ActiveRecord::StatementInvalid )
+          end
+        end
+      end
+    end
+
+    context '#manually_dated_destruction_in' do
+      before :each do
+        @data   = Hoodoo::UUID.generate()
+        @record = RSpecModelManualDateTest.new( {
+          :data       => @data,
+          :created_at => @now,
+          :updated_at => @now
+        } )
+
+        @record.save!
+        @old_updated_at = @record.updated_at
+
+        @context.request.instance_variable_set( '@ident', @record.uuid )
+      end
+
+      # Call only for 'successful' delete cases. Pass the result of a call to
+      # #manually_dated_update_in. Expects:
+      #
+      # * One fewer 'current' items
+      # * One more 'historic' item
+      # * One unscoped thing can now be found by @record's UUID
+      # * It should have the correct bounding dates and data.
+      #
+      # Remember that the very top of this file seeds in 2 contemporary and
+      # 4 historical entries, so counts are relative to that baseline.
+      #
+      def run_expectations( result )
+        expect( RSpecModelManualDateTest.manually_dated_contemporary.count ).to eq( 2 )
+        expect( RSpecModelManualDateTest.manually_dated_historic.count ).to eq( 5 )
+        expect( RSpecModelManualDateTest.manually_dated_contemporary.where( :uuid => @record.uuid ).count ).to eq( 0 )
+        expect( RSpecModelManualDateTest.manually_dated_historic.where( :uuid => @record.uuid ).count ).to eq( 1 )
+
+        # Current record is now at 'no'/nil time - i.e. actually Time.now. The
+        # time frozen into "@now" at the top of this file is by this point the
+        # historic time of the old record.
+
+        historic = RSpecModelManualDateTest.manually_dated_at( @now ).find_by_uuid( @record.uuid )
+
+        expect( historic.data ).to eq( @data )
+
+        expect( historic.effective_end ).to_not be_nil
+        expect( historic.updated_at ).to eq( @old_updated_at )
+      end
+
+      it 'via context alone' do
+        result = RSpecModelManualDateTest.manually_dated_destruction_in(
+          @context
+        )
+
+        run_expectations( result )
+      end
+
+      # Generate a random => invalid UUID in the request data to prove that
+      # the valid one given in the input parameter is used as an override.
+      #
+      it 'specifying "ident"' do
+        @context.request.instance_variable_set( '@ident', Hoodoo::UUID.generate() )
+
+        result = RSpecModelManualDateTest.manually_dated_destruction_in(
+          @context,
+          ident: @record.uuid
+        )
+
+        run_expectations( result )
+      end
+
+      it 'uses a given scope' do
+
+        # We expect the custom scope to be customised to find an
+        # contemporary dated record for locking, if it's being used
+        # OK. This is fragile; depends heavily on implementation.
+
+        custom_scope = RSpecModelManualDateTest.where( :data => [ 'one', 'two', 'three' ] + [ @data ] )
+        expect( custom_scope ).to receive( :manually_dated_contemporary ).and_call_original
+
+        result = RSpecModelManualDateTest.manually_dated_destruction_in(
+          @context,
+          scope: custom_scope
+        )
+
+        run_expectations( result )
+      end
+
+      context 'handles not-found' do
+        it 'because of a bad identifier' do
+          result = RSpecModelManualDateTest.manually_dated_destruction_in(
+            @context,
+            ident: Hoodoo::UUID.generate() # Random => invalid
+          )
+
+          expect( result ).to be_nil
+        end
+
+        it 'because of a scope' do
+          result = RSpecModelManualDateTest.manually_dated_destruction_in(
+            @context,
+            scope: RSpecModelManualDateTest.where( :data => [ Hoodoo::UUID.generate() ] ) # Random => invalid
+          )
+
+          expect( result ).to be_nil
+        end
+      end
+    end
+
+    context 'update then delete' do
+      it 'works' do
+        record = RSpecModelManualDateTest.new( {
+          :data       => Hoodoo::UUID.generate(),
+          :created_at => @now,
+          :updated_at => @now
+        } )
+
+        record.save!
+
+        3.times do
+          result = RSpecModelManualDateTest.manually_dated_update_in(
+            @context,
+            ident: record.uuid,
+            attributes: { 'data' => Hoodoo::UUID.generate() }
+          )
+
+          expect( result ).to_not be_nil
+          expect( result.persisted? ).to eq( true )
+        end
+
+        result = RSpecModelManualDateTest.manually_dated_destruction_in(
+          @context,
+          ident: record.uuid
+        )
+
+        expect( result ).to_not be_nil
+
+        # We start with one current record, but it gets updated three times,
+        # creating three history entries. Then it gets deleted, creating
+        # another history entry and leaving no current ones.
+        #
+        # Remember that the very top of this file seeds in 2 contemporary and
+        # 4 historical entries, so counts are relative to that baseline.
+
+        expect( RSpecModelManualDateTest.manually_dated_contemporary.count ).to eq( 2 )
+        expect( RSpecModelManualDateTest.manually_dated_historic.count ).to eq( 8 )
+        expect( RSpecModelManualDateTest.manually_dated_contemporary.where( :uuid => record.uuid ).count ).to eq( 0 )
+        expect( RSpecModelManualDateTest.manually_dated_historic.where( :uuid => record.uuid ).count ).to eq( 4 )
+      end
+    end
+  end
+
+  context 'concurrent' do
+    before :all do
+      DatabaseCleaner.strategy = :truncation
+    end
+
+    after :all do
+      DatabaseCleaner.strategy = DATABASE_CLEANER_STRATEGY # spec_helper.rb
+    end
+
+    before :each do
+      @uuids   = []
+      @results = {}
+      @mutex   = Mutex.new
+
+      # From a pool of UUIDs, create a bunch of records.
+
+      50.times { @uuids << Hoodoo::UUID.generate }
+      @uuids.uniq! # Just in case I should've entered the lottery this week
+
+      @uuids.each do | uuid |
+        RSpecModelManualDateTest.new( {
+          :uuid => uuid,
+          :data => '0'
+        } ).save!
+      end
+    end
+
+    def add_result( uuid, result )
+      @mutex.synchronize do
+        @results[ uuid ] ||= []
+        @results[ uuid ] << result
+      end
+    end
+
+    # - Start threads that update the records with values, one update per thread
+    # - Check that the combined unscoped set has all integers and nothing more
+    # - Check there is only one contemporary entry per UUID and num-ints-minus-one
+    #   history entries
+    #
+    it 'updates work' do
+      values  = ( '1'..'9' ).to_a
+      threads = []
+
+      @uuids.each do | uuid |
+        values.each do | value |
+          threads << Thread.new do
+            ActiveRecord::Base.connection_pool.with_connection do
+              sleep 0.001 # Force Thread scheduler to run
+
+              result = RSpecModelManualDateTest.manually_dated_update_in(
+                @context,
+                ident: uuid,
+                attributes: { 'data' => value }
+              )
+
+              add_result( uuid, result )
+            end
+          end
+        end
+      end
+
+      threads.each { | thread | thread.join() }
+
+      @uuids.each do | uuid |
+        contemporary = RSpecModelManualDateTest.manually_dated_contemporary.where( :uuid => uuid ).to_a
+        historic     = RSpecModelManualDateTest.manually_dated_historic.where( :uuid => uuid ).to_a
+
+        expect( contemporary.count ).to eq( 1 )
+        expect( historic.count     ).to eq( values.count )
+
+        # Across all records, the starting data value of "0" plus any
+        # new items in "values" should be present exactly once.
+
+        combined = ( contemporary + historic ).map( & :data )
+        expect( combined ).to match_array( [ '0' ] + values )
+
+        # All results should be persisted model instances which, once
+        # reloaded, only have one contemporary entry and the rest historic.
+        # This double-checks the database query tests a few lines above.
+
+        results = @results[ uuid ]
+
+        results.each do | result |
+          expect( result ).to be_a( RSpecModelManualDateTest )
+          expect( result.errors ).to be_empty
+          expect( result.persisted? ).to eq( true )
+
+          result.reload
+        end
+
+        dates  = results.map( & :effective_end )
+        nils   = dates.select() { | date | date.nil? }
+        others = dates.reject() { | date | date.nil? }
+
+        # "- 1" because the results Hash only contains results of the
+        # *updates* we did, not the original starting record.
+
+        expect(   nils.count ).to eq( 1 )
+        expect( others.count ).to eq( values.count - 1 )
+      end
+    end
+
+    # - Start several threads that delete the same records
+    # - Push results into the results hash
+    # - Check that only one thread succeeded, rest of them got 'nil' (not found),
+    #     only one history entry per UUID, no contemporary entry per UUID.
+    #
+    it 'deletions work' do
+      threads  = []
+      attempts = 10
+
+      @uuids.each do | uuid |
+        attempts.times do
+          threads << Thread.new do
+            ActiveRecord::Base.connection_pool.with_connection do
+              result = RSpecModelManualDateTest.manually_dated_destruction_in(
+                @context,
+                ident: uuid
+              )
+
+              add_result( uuid, result )
+            end
+          end
+        end
+      end
+
+      threads.each { | thread | thread.join() }
+
+      @uuids.each do | uuid |
+        contemporary = RSpecModelManualDateTest.manually_dated_contemporary.where( :uuid => uuid ).to_a
+        historic     = RSpecModelManualDateTest.manually_dated_historic.where( :uuid => uuid ).to_a
+
+        expect( contemporary.count ).to eq( 0 )
+        expect( historic.count     ).to eq( 1 )
+
+        # We expect all results to contain one success and lots of failures.
+
+        results   = @results[ uuid ]
+        failures  = results.select() { | result | result.nil? }
+        successes = results.reject() { | result | result.nil? }
+
+        expect( failures.count  ).to eq( attempts - 1 )
+        expect( successes.count ).to eq( 1 )
+
+        success = successes.first
+        success.reload
+
+        expect( success ).to be_a( RSpecModelManualDateTest )
+        expect( success.errors ).to be_empty
+        expect( success.persisted? ).to eq( true )
+        expect( success.effective_end ).to_not be_nil
+      end
+    end
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,7 +73,8 @@ RSpec.configure do | config |
 
   # Wake up Database Cleaner.
 
-  DatabaseCleaner.strategy = :transaction # MUST NOT be changed
+  DATABASE_CLEANER_STRATEGY = :transaction # MUST NOT be changed
+  DatabaseCleaner.strategy = DATABASE_CLEANER_STRATEGY
 
   database_name = 'hoodoo_test'
 

--- a/spec/utilities/uuid_spec.rb
+++ b/spec/utilities/uuid_spec.rb
@@ -1,20 +1,152 @@
 require 'spec_helper'
 
 describe Hoodoo::UUID do
+  before :all do
+    valid_v4_full_uuids = [
+    # 'xxxxxxxx-xxxx-4xxx-Yxxx-xxxxxxxxxxxx' Y = 8,9,A,B,a,b
+      '01234567-89AB-4CDE-8Fab-cdef00000000',
+      '01234567-89AB-4CDE-9Fab-cdef00000000',
+      '01234567-89AB-4CDE-AFab-cdef00000000',
+      '01234567-89AB-4CDE-BFab-cdef00000000',
+      '01234567-89AB-4CDE-aFab-cdef00000000',
+      '01234567-89AB-4CDE-bFab-cdef00000000'
+    ]
 
-  describe '#generate' do
-    it 'should generate a 32 character string' do
-      uuid = Hoodoo::UUID.generate
+    @valid_uuids = valid_v4_full_uuids.map { | uuid | uuid.gsub( '-', '' ) }
+  end
 
-      expect(uuid).to be_a(String)
-      expect(uuid.length).to eq(32)
+  context '#generate' do
+    it 'generates a 32 character string' do
+      uuid = Hoodoo::UUID.generate()
+
+      expect( uuid        ).to be_a( String )
+      expect( uuid.length ).to eq( 32 )
     end
 
-    it 'should not generate the same uuid twice' do
-      uuid1 = Hoodoo::UUID.generate
-      uuid2 = Hoodoo::UUID.generate
+    it 'generates a 16 hex digit pair string' do
+      uuid = Hoodoo::UUID.generate()
+      expect( uuid =~ Hoodoo::UUID::MATCH_16_PAIRS_OF_HEX_DIGITS ).to_not be_nil
+    end
 
-      expect(uuid1).not_to eq(uuid2)
+    it 'does not generate the same UUID twice' do
+      100.times do
+        uuid1 = Hoodoo::UUID.generate()
+        uuid2 = Hoodoo::UUID.generate()
+
+        expect( uuid1 ).not_to eq( uuid2 )
+      end
+    end
+  end
+
+  context '#valid?' do
+    it 'validates known-good UUIDs' do
+      @valid_uuids.each do | uuid |
+        expect( Hoodoo::UUID.valid?( uuid ) ).to eq( true )
+      end
+    end
+
+    it 'validates internally generated UUIDs' do
+      100.times do
+        uuid = Hoodoo::UUID.generate()
+        expect( Hoodoo::UUID.valid?( uuid ) ).to eq( true )
+      end
+    end
+
+    it 'rejects non-string items' do
+      uuid = Hoodoo::UUID.generate()
+      expect( Hoodoo::UUID.valid?( uuid.to_sym ) ).to eq( false )
+    end
+
+    it 'rejects the wrong version check digit' do
+      value = @valid_uuids.first.dup
+      value[ 12 ] = '0'
+
+      expect( Hoodoo::UUID.valid?( value ) ).to eq( false )
+    end
+
+    it 'does not match the wrong other check digit' do
+      value = @valid_uuids.first.dup
+      value[ 16 ] = '0'
+
+      expect( Hoodoo::UUID.valid?( value ) ).to eq( false )
+    end
+
+    it 'does not match non-hex digits' do
+      value = @valid_uuids.first.dup
+      value[ 0 ] = 'Z'
+
+      expect( Hoodoo::UUID.valid?( value ) ).to eq( false )
+    end
+
+    it 'does not match too-short strings' do
+      value = @valid_uuids.first[ 0..30 ]
+      expect( Hoodoo::UUID.valid?( value ) ).to eq( false )
+    end
+
+    it 'does not match too-long strings' do
+      value = @valid_uuids.first + '0'
+      expect( Hoodoo::UUID.valid?( value ) ).to eq( false )
+    end
+  end
+
+  context 'MATCH_16_PAIRS_OF_HEX_DIGITS' do
+    it 'matches 32 hex digits in any case' do
+      value = '0123456789ABCDEFabcdef0123456789'
+      expect( value =~ Hoodoo::UUID::MATCH_16_PAIRS_OF_HEX_DIGITS ).to_not be_nil
+    end
+
+    it 'does not match non-hex digits' do
+      value = '0123456789ABCDEFabcZef0123456789'
+      expect( value =~ Hoodoo::UUID::MATCH_16_PAIRS_OF_HEX_DIGITS ).to be_nil
+    end
+
+    it 'does not match too-short strings' do
+      value = '0123456789ABCDEFabcdef012345678'
+      expect( value =~ Hoodoo::UUID::MATCH_16_PAIRS_OF_HEX_DIGITS ).to be_nil
+    end
+
+    it 'does not match too-long strings' do
+      value = '0123456789ABCDEFabcdef0123456789A'
+      expect( value =~ Hoodoo::UUID::MATCH_16_PAIRS_OF_HEX_DIGITS ).to be_nil
+    end
+  end
+
+  context 'MATCH_V4_UUID' do
+    it 'matches known-good UUIDs' do
+      @valid_uuids.each do | uuid |
+        expect( uuid =~ Hoodoo::UUID::MATCH_V4_UUID ).to_not be_nil
+      end
+    end
+
+    it 'does not match the wrong version check digit' do
+      value = @valid_uuids.first.dup
+      value[ 12 ] = '0'
+
+      expect( value =~ Hoodoo::UUID::MATCH_V4_UUID ).to be_nil
+    end
+
+    it 'does not match the wrong other check digit' do
+      value = @valid_uuids.first.dup
+      value[ 16 ] = '0'
+
+      expect( value =~ Hoodoo::UUID::MATCH_V4_UUID ).to be_nil
+    end
+
+    it 'does not match non-hex digits' do
+      value = @valid_uuids.first.dup
+      value[ 0 ] = 'Z'
+
+      expect( value =~ Hoodoo::UUID::MATCH_V4_UUID ).to be_nil
+    end
+
+    it 'does not match too-short strings' do
+      value = @valid_uuids.first[ 0..30 ]
+      expect( value =~ Hoodoo::UUID::MATCH_V4_UUID ).to be_nil
+    end
+
+    it 'does not match too-long strings' do
+      value = @valid_uuids.first + '0'
+      expect( value =~ Hoodoo::UUID::MATCH_V4_UUID ).to be_nil
     end
   end
 end


### PR DESCRIPTION
Introduce a "manual" historic (effective) dating engine that can sit alongside the automatic one, at least in terms of mixin namespace; it wouldn't make sense to have both of them active at the same time.

Close attention is needed in particular for the locking sections of the update and destruction methods in the new module. Deadlock retry is unsatisfactory but seems at present unavoidable.

Note unavoidable clumsy use of `uuid` column to now hold the model's _actual resource_ UUID, as would be reported in an `id` field of a JSON API response; while `id` must still be the primary key. Even if we tell ActiveRecord that the database uses a column of a different name, ActiveRecord will provide an `id` accessor no matter what; it's deeply embedded magic in AR. However the value for the primary key _must_ be unscoped-unique or attempts to, say, update a single column's value will result in an ambiguous SQL `UPDATE` query being generated that matches all current or historical rows for a given resource UUID, with catastrophic results. Consequently we have another unsatisfactory but unavoidable situation of service authors who lean on manual dating needing to remember the `uuid` field of their resource and _NOT_ the `id` field - nothing would be found from the actual `id` value via the `acquire` family of Finder mixin methods (or worse, you might find an arbitrary historic entry regardless of requested date).

RDoc data and a new version will be done via a separate PR since this one is more than complicated enough already.

Brings in a UUID performance improvement in passing.