### PR TITLE
Hotfix/creator and docs

### DIFF
--- a/lib/hoodoo/active/active_record/creator.rb
+++ b/lib/hoodoo/active/active_record/creator.rb
@@ -30,7 +30,7 @@ module Hoodoo
     #
     # ...to create model instances and participate "for free" in whatever
     # plug-in ActiveRecord modules are mixed into the model classes, such as
-    # Hoodoo::ActiveRecord::Dated.
+    # Hoodoo::ActiveRecord::Dated and Hoodoo::ActiveRecord::ManuallyDated.
     #
     # See also:
     #
@@ -117,12 +117,13 @@ module Hoodoo
 
           # TODO: Refactor this to use the scope chain plugin approach in due
           #       course, but for now, pragmatic implementation does the only
-          #       thing we currently need to do - set "created_at".
+          #       things we currently require - set "created_at"/"updated_at".
           #
-          if self.include?( Hoodoo::ActiveRecord::Dated )
-            unless context.request.dated_from.nil?
-              instance.created_at = instance.updated_at = context.request.dated_from
-            end
+          unless context.request.dated_from.nil?
+            instance.created_at = instance.updated_at = context.request.dated_from if (
+              ( self.include?( Hoodoo::ActiveRecord::Dated         ) && self.dating_enabled?()        ) ||
+              ( self.include?( Hoodoo::ActiveRecord::ManuallyDated ) && self.manual_dating_enabled?() )
+            )
           end
 
           return instance

--- a/lib/hoodoo/active/active_record/dated.rb
+++ b/lib/hoodoo/active/active_record/dated.rb
@@ -97,9 +97,9 @@ module Hoodoo
     #
     # == Model instance creation
     #
-    # It is _VERY_ _IMPORTANT_ that you use
-    # Hoodoo::ActiveRecord::Creator::ClassMethods::new_in to create new
-    # resource instances when using Dating. You _could_ just manually read the
+    # It is _VERY_ _IMPORTANT_ that you use method
+    # Hoodoo::ActiveRecord::Creator::ClassMethods.new_in to create new
+    # resource instances when using dating. You _could_ just manually read the
     # `context.request.dated_from` value to ensure that an appropriate creation
     # time is set; presently, `created_at` and `updated_at` are set from the
     # `dated_from` value. However, using `new_in` for this isolates your code
@@ -183,7 +183,7 @@ module Hoodoo
         # returns +true+, else +false+.
         #
         def dating_enabled?
-          return self.dated_with() != nil?
+          return self.dated_with().present?
         end
 
         # Return an ActiveRecord::Relation containing the model instances which

--- a/lib/hoodoo/active/active_record/manually_dated.rb
+++ b/lib/hoodoo/active/active_record/manually_dated.rb
@@ -184,7 +184,7 @@ module Hoodoo
     # one complex resource may be represented by several models with
     # relationships between them.
     #
-    # In such cas, remember to set foreign keys for any relational declarations
+    # In such cases, remember to set foreign keys for relational declarations
     # to a manually dated table via the +uuid+ column - e.g. go from this:
     #
     #     member.account_id = account.id

--- a/lib/hoodoo/active/active_record/manually_dated.rb
+++ b/lib/hoodoo/active/active_record/manually_dated.rb
@@ -109,6 +109,8 @@ module Hoodoo
     # you *MUST* include the ActiveRecord::Relation instances (scopes) inside
     # any query chain used to read or write data.
     #
+    # === Show and List
+    #
     # You might use Hoodoo::ActiveRecord::Finder#list_in or
     # Hoodoo::ActiveRecord::Finder#acquire_in for +list+ or +show+ actions;
     # such code changes from e.g.:
@@ -119,7 +121,20 @@ module Hoodoo
     #
     #     SomeModel.manually_dated( context ).list_in( context )
     #
-    # You MUST NOT update or delete records using conventional ActiveRecord
+    # === Create
+    #
+    # As with automatic dating - see Hoodoo::ActiveRecord::Dated - you should
+    # use method Hoodoo::ActiveRecord::Creator::ClassMethods.new_in to create
+    # new resource instances, to help ensure correct initial date setup and to
+    # help isolate your code from future functionality extensions/changes. An
+    # ActiveRecord +before_create+ filter deals with some of the "behind the
+    # scenes" maintenance but the initial acquisition of dating information
+    # from the prevailing request context only happens for you if you use
+    # Hoodoo::ActiveRecord::Creator::ClassMethods::new_in.
+    #
+    # === Update and Delete
+    #
+    # You *MUST* *NOT* update or delete records using conventional ActiveRecord
     # methods if you want to use manual dating to record state changes.
     # Instead, use
     # Hoodoo::ActiveRecord::ManuallyDated::ClassMethods#manually_dated_update_in
@@ -143,6 +158,8 @@ module Hoodoo
     # information on overriding the identifier used to find the target record
     # and the attribute data used for updates.
     #
+    # == Rendering
+    #
     # When rendering, you *MUST* remember to set the resource's +id+ field
     # from the model's +uuid+ field:
     #
@@ -155,8 +172,20 @@ module Hoodoo
     #       }
     #     )
     #
-    # Likewise, remember to set foreign keys for any relational declarations
-    # via the +uuid+ column - e.g. go from this:
+    # == Associations
+    #
+    # Generally, use of ActiveRecord associations is minimal in most services
+    # because there is an implied database-level coupling of resources and a
+    # temptation to use cross-table ActiveRecord mechanisms for things like
+    # relational UUID integrity checks, rather than inter-resource calls.
+    # Doing so couples resources together at the database rather than keeping
+    # them isolated purely by API, which is often a really bad idea. It is,
+    # however, sometimes necessary for best possible performance, or sometimes
+    # one complex resource may be represented by several models with
+    # relationships between them.
+    #
+    # In such cas, remember to set foreign keys for any relational declarations
+    # to a manually dated table via the +uuid+ column - e.g. go from this:
     #
     #     member.account_id = account.id
     #
@@ -407,10 +436,6 @@ module Hoodoo
         #
         def manual_dating_enabled
           self.nz_co_loyalty_hoodoo_manually_dated = true
-
-          rounder = Proc.new do | timelike |
-            timelike.to_time.round( SECONDS_DECIMAL_PLACES )
-          end
 
           # This is the 'tightest'/innermost callback available for creation.
           # Intentionally have nothing for updates/deletes as the high level

--- a/spec/active/active_record/dated_spec.rb
+++ b/spec/active/active_record/dated_spec.rb
@@ -124,8 +124,14 @@ describe Hoodoo::ActiveRecord::Dated do
     end
 
     context '#dating_enabled?' do
+      class RSpecNotDated < Hoodoo::ActiveRecord::Base; end
+
       it 'says it is automatically dated' do
         expect( model_klass.dating_enabled? ).to eq( true )
+      end
+
+      it 'knows when something is not automatically dated' do
+        expect( RSpecNotDated.dating_enabled? ).to eq( false )
       end
     end
 

--- a/spec/active/active_record/manually_dated_spec.rb
+++ b/spec/active/active_record/manually_dated_spec.rb
@@ -139,8 +139,14 @@ describe Hoodoo::ActiveRecord::ManuallyDated do
     end
 
     context '#manual_dating_enabled?' do
+      class RSpecNotManuallyDated < Hoodoo::ActiveRecord::Base; end
+
       it 'says it is manually dated' do
         expect( RSpecModelManualDateTest.manual_dating_enabled? ).to eq( true )
+      end
+
+      it 'knows when something is not automatically dated' do
+        expect( RSpecNotManuallyDated.manual_dating_enabled? ).to eq( false )
       end
     end
 


### PR DESCRIPTION
* Fix method `dating_enabled?`, with corrected test coverage
* Apply equivalent coverage to `manual_dating_enabled?`
* Creator mixin wasn't updated for manual dating - do this and add proper test coverage
* Improve manual dating documentation via subsections; remove a leftover `Proc` from a prior refactor

I've done a search sweep for checks on the `Hoodoo::ActiveRecord::Dated` mixin to make sure there are no other overlooked places where conditional execution occurs on the basis of its presence; there are none that I could find.