### PR TITLE
Hotfix/uuid mixin validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1 (2016-02-18)
+
+* Important fix for historic manual dating variants (version 1.2.x and 1.3.0). UUID validation at the application layer for normal, non-dated resources was broken because of an overlooked piece of stale code. Fixed, including previously missing test coverage to ensure no future regression.
+
 ## 1.3.0 (2016-02-17)
 
 * Improved exception reporting through the new `contextual_report` mechanism, which the middleware now uses and the Airbrake and Raygun reporters take advantage of.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    hoodoo (1.3.0)
+    hoodoo (1.3.1)
       dalli (~> 2.7)
       kgio (~> 2.9)
 
@@ -31,7 +31,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    airbrake (4.3.5)
+    airbrake (4.3.6)
       builder
       multi_json
     alchemy-flux (0.1.2)

--- a/docs/rdoc/classes/Hoodoo.html
+++ b/docs/rdoc/classes/Hoodoo.html
@@ -1221,7 +1221,7 @@ thing.</p>
           <tr valign='top' id='VERSION'>
             <td class="attr-name">VERSION</td>
             <td>=</td>
-            <td class="attr-value"><pre>&#39;1.3.0&#39;</pre></td>
+            <td class="attr-value"><pre>&#39;1.3.1&#39;</pre></td>
           </tr>
             <tr valign='top'>
               <td>&nbsp;</td>

--- a/docs/rdoc/classes/Hoodoo/ActiveRecord/UUID.html
+++ b/docs/rdoc/classes/Hoodoo/ActiveRecord/UUID.html
@@ -180,26 +180,9 @@ including this module.</p>
     {
       <span class="ruby-value">:uuid</span>       =<span class="ruby-operator">&gt;</span> <span class="ruby-keyword">true</span>,
       <span class="ruby-value">:presence</span>   =<span class="ruby-operator">&gt;</span> <span class="ruby-keyword">true</span>,
-      <span class="ruby-value">:uniqueness</span> =<span class="ruby-operator">&gt;</span> <span class="ruby-keyword">true</span>,
+      <span class="ruby-value">:uniqueness</span> =<span class="ruby-operator">&gt;</span> <span class="ruby-keyword">true</span>
     }
   )
-
-  <span class="ruby-comment"># We also have to remove ActiveRecord&#39;s default unscoped uniqueness</span>
-  <span class="ruby-comment"># check on &#39;id&#39;. We&#39;ve added an equivalent validator above.</span>
-  <span class="ruby-comment">#</span>
-  <span class="ruby-comment"># Sadly there is no API for this even as late as ActiveRecord 4.2,</span>
-  <span class="ruby-comment"># so we have to resort to fragile hackery.</span>
-  <span class="ruby-comment">#</span>
-  <span class="ruby-identifier">model</span>.<span class="ruby-identifier">_validators</span>.<span class="ruby-identifier">reject!</span>() <span class="ruby-keyword">do</span> <span class="ruby-operator">|</span> <span class="ruby-identifier">key</span>, <span class="ruby-identifier">ignored</span> <span class="ruby-operator">|</span>
-    <span class="ruby-identifier">key</span> <span class="ruby-operator">==</span> <span class="ruby-value">:id</span>
-  <span class="ruby-keyword">end</span>
-
-  <span class="ruby-identifier">id_validation_callback</span> = <span class="ruby-identifier">model</span>.<span class="ruby-identifier">_validate_callbacks</span>.<span class="ruby-identifier">find</span> <span class="ruby-keyword">do</span> <span class="ruby-operator">|</span> <span class="ruby-identifier">callback</span> <span class="ruby-operator">|</span>
-    <span class="ruby-identifier">callback</span>.<span class="ruby-identifier">raw_filter</span>.<span class="ruby-identifier">is_a?</span>( <span class="ruby-operator">::</span><span class="ruby-constant">ActiveRecord</span><span class="ruby-operator">::</span><span class="ruby-constant">Validations</span><span class="ruby-operator">::</span><span class="ruby-constant">UniquenessValidator</span> ) <span class="ruby-operator">&amp;&amp;</span>
-    <span class="ruby-identifier">callback</span>.<span class="ruby-identifier">raw_filter</span>.<span class="ruby-identifier">attributes</span> <span class="ruby-operator">==</span> [ <span class="ruby-value">:id</span> ]
-  <span class="ruby-keyword">end</span>
-
-  <span class="ruby-identifier">model</span>.<span class="ruby-identifier">_validate_callbacks</span>.<span class="ruby-identifier">delete</span>( <span class="ruby-identifier">id_validation_callback</span> )
 <span class="ruby-keyword">end</span></pre>
               </div>
             </div>

--- a/docs/rdoc/classes/Hoodoo/Services/Middleware/ExceptionReporting/BaseReporter.html
+++ b/docs/rdoc/classes/Hoodoo/Services/Middleware/ExceptionReporting/BaseReporter.html
@@ -302,7 +302,7 @@ href="../../../../Rack.html">Rack</a> request handling.</p>
 
             <div class="description">
               <p>When passed a request context, extracts information that can be given as
-“user data” (or similar) to a exception reporting endpoint, if it supports
+“user data” (or similar) to an exception reporting endpoint, if it supports
 such a concept.</p>
 <dl class="rdoc-list note-list"><dt><code>context</code>
 <dd>

--- a/docs/rdoc/created.rid
+++ b/docs/rdoc/created.rid
@@ -1,4 +1,4 @@
-Wed, 17 Feb 2016 17:44:08 +1300
+Thu, 18 Feb 2016 14:18:58 +1300
 README.md	Thu, 14 Jan 2016 15:40:47 +1300
 lib/hoodoo.rb	Thu, 14 Jan 2016 15:15:01 +1300
 lib/hoodoo/active.rb	Mon, 15 Feb 2016 10:21:55 +1300
@@ -13,7 +13,7 @@ lib/hoodoo/active/active_record/search_helper.rb	Thu, 14 Jan 2016 15:15:01 +1300
 lib/hoodoo/active/active_record/secure.rb	Mon, 15 Feb 2016 10:21:55 +1300
 lib/hoodoo/active/active_record/support.rb	Mon, 15 Feb 2016 10:21:55 +1300
 lib/hoodoo/active/active_record/translated.rb	Mon, 15 Feb 2016 10:21:55 +1300
-lib/hoodoo/active/active_record/uuid.rb	Mon, 15 Feb 2016 10:21:55 +1300
+lib/hoodoo/active/active_record/uuid.rb	Thu, 18 Feb 2016 14:05:42 +1300
 lib/hoodoo/active/active_record/writer.rb	Mon, 15 Feb 2016 10:21:55 +1300
 lib/hoodoo/client.rb	Thu, 14 Jan 2016 15:15:01 +1300
 lib/hoodoo/client/augmented_array.rb	Thu, 14 Jan 2016 15:15:01 +1300
@@ -91,12 +91,12 @@ lib/hoodoo/services/middleware/amqp_log_message.rb	Tue, 26 Jan 2016 14:26:24 +13
 lib/hoodoo/services/middleware/amqp_log_writer.rb	Tue, 26 Jan 2016 14:26:24 +1300
 lib/hoodoo/services/middleware/endpoints/inter_resource_local.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/services/middleware/endpoints/inter_resource_remote.rb	Fri, 29 Jan 2016 15:42:39 +1300
-lib/hoodoo/services/middleware/exception_reporting/base_reporter.rb	Wed, 17 Feb 2016 17:42:16 +1300
-lib/hoodoo/services/middleware/exception_reporting/exception_reporting.rb	Wed, 17 Feb 2016 15:52:00 +1300
-lib/hoodoo/services/middleware/exception_reporting/reporters/airbrake_reporter.rb	Wed, 17 Feb 2016 17:04:40 +1300
-lib/hoodoo/services/middleware/exception_reporting/reporters/raygun_reporter.rb	Wed, 17 Feb 2016 17:05:00 +1300
+lib/hoodoo/services/middleware/exception_reporting/base_reporter.rb	Thu, 18 Feb 2016 10:14:18 +1300
+lib/hoodoo/services/middleware/exception_reporting/exception_reporting.rb	Thu, 18 Feb 2016 09:28:54 +1300
+lib/hoodoo/services/middleware/exception_reporting/reporters/airbrake_reporter.rb	Thu, 18 Feb 2016 09:28:54 +1300
+lib/hoodoo/services/middleware/exception_reporting/reporters/raygun_reporter.rb	Thu, 18 Feb 2016 09:28:54 +1300
 lib/hoodoo/services/middleware/interaction.rb	Thu, 14 Jan 2016 15:15:02 +1300
-lib/hoodoo/services/middleware/middleware.rb	Wed, 17 Feb 2016 17:32:01 +1300
+lib/hoodoo/services/middleware/middleware.rb	Thu, 18 Feb 2016 09:28:54 +1300
 lib/hoodoo/services/middleware/rack_monkey_patch.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/services/services/context.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/services/services/implementation.rb	Thu, 14 Jan 2016 15:15:02 +1300
@@ -110,4 +110,4 @@ lib/hoodoo/utilities.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/utilities/string_inquirer.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/utilities/utilities.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/utilities/uuid.rb	Mon, 15 Feb 2016 10:21:55 +1300
-lib/hoodoo/version.rb	Wed, 17 Feb 2016 17:34:45 +1300
+lib/hoodoo/version.rb	Thu, 18 Feb 2016 14:18:28 +1300

--- a/hoodoo.gemspec
+++ b/hoodoo.gemspec
@@ -4,7 +4,7 @@ require 'hoodoo/version'
 Gem::Specification.new do | s |
   s.name        = 'hoodoo'
   s.version     = Hoodoo::VERSION
-  s.date        = '2016-02-17'
+  s.date        = '2016-02-18'
   s.summary     = 'Opinionated APIs'
   s.description = 'Simplify the implementation of consistent services within an API-based software platform.'
   s.authors     = [ 'Loyalty New Zealand' ]

--- a/lib/hoodoo/active/active_record/uuid.rb
+++ b/lib/hoodoo/active/active_record/uuid.rb
@@ -77,26 +77,9 @@ module Hoodoo
           {
             :uuid       => true,
             :presence   => true,
-            :uniqueness => true,
+            :uniqueness => true
           }
         )
-
-        # We also have to remove ActiveRecord's default unscoped uniqueness
-        # check on 'id'. We've added an equivalent validator above.
-        #
-        # Sadly there is no API for this even as late as ActiveRecord 4.2,
-        # so we have to resort to fragile hackery.
-        #
-        model._validators.reject!() do | key, ignored |
-          key == :id
-        end
-
-        id_validation_callback = model._validate_callbacks.find do | callback |
-          callback.raw_filter.is_a?( ::ActiveRecord::Validations::UniquenessValidator ) &&
-          callback.raw_filter.attributes == [ :id ]
-        end
-
-        model._validate_callbacks.delete( id_validation_callback )
       end
 
     end

--- a/lib/hoodoo/services/middleware/exception_reporting/base_reporter.rb
+++ b/lib/hoodoo/services/middleware/exception_reporting/base_reporter.rb
@@ -142,7 +142,7 @@ module Hoodoo; module Services
         protected
 
         # When passed a request context, extracts information that can be given
-        # as "user data" (or similar) to a exception reporting endpoint, if it
+        # as "user data" (or similar) to an exception reporting endpoint, if it
         # supports such a concept.
         #
         # +context+:: Hoodoo::Services::Context instance describing an

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -12,6 +12,6 @@ module Hoodoo
   # The Hoodoo gem version. If this changes, ensure that the date in
   # "hoodoo.gemspec" is correct and run "bundle install" (or "update").
   #
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 
 end

--- a/spec/active/active_record/manually_dated_spec.rb
+++ b/spec/active/active_record/manually_dated_spec.rb
@@ -102,7 +102,7 @@ describe Hoodoo::ActiveRecord::ManuallyDated do
       [ @uuid_a, 'six',   @now - 5.hours, @now - 1.hour,  @eot            ]
     ].each do | row_data |
       RSpecModelManualDateTest.new( {
-        :id              => row_data[ 0 ],
+        :uuid            => row_data[ 0 ],
         :data            => row_data[ 1 ],
         :created_at      => row_data[ 2 ],
         :updated_at      => row_data[ 2 ],

--- a/spec/active/active_record/uuid_spec.rb
+++ b/spec/active/active_record/uuid_spec.rb
@@ -69,4 +69,15 @@ describe Hoodoo::ActiveRecord::UUID do
     m.reload
     expect( m.id ).to eq( id )
   end
+
+  it 'should not allow a duplicate UUID at the application level' do
+    m = RSpecModelUUIDTest.new
+    m.save
+
+    n = RSpecModelUUIDTest.new
+    n.id = m.id
+
+    expect( n ).to be_invalid
+    expect( n.errors[ :id ] ).to eq( [ 'has already been taken' ] )
+  end
 end


### PR DESCRIPTION
Important bug fix. During work on manual dating, there were quite a few changes in direction on the use of the `id` column. In one code variant, the UUID mixin needed to include code that removed ActiveRecord default application-level validations on the uniqueness of the `id` column. Later this changed but the removal was still present, so no application level uniqueness constraint remained. Although all associated database records for any Hoodoo user _really_ should have a database-level constraint on the primary key's uniqueness anyway, this is still a serious fault.

Fixed, with test coverage to prevent reoffending! Drive-by minor comment fix and a bunch of RDoc change spam from that plus the bump to version 1.3.1. Once merged, this will be tagged and pushed out as a public release.