### PR TITLE
Don't rescue Exception explicitly; rescue StandardError implicitly

### DIFF
--- a/lib/hoodoo/services/services/session.rb
+++ b/lib/hoodoo/services/services/session.rb
@@ -192,7 +192,7 @@ module Hoodoo
                                      self.to_h(),
                                      TTL )
 
-        rescue Exception => exception
+        rescue => exception
 
           # Log error and return nil if the session can't be parsed
           #
@@ -245,7 +245,7 @@ module Hoodoo
             end
           end
 
-        rescue Exception => exception
+        rescue => exception
 
           # Log error and return nil if the session can't be parsed
           #
@@ -301,7 +301,7 @@ module Hoodoo
             return :ok
           end
 
-        rescue Exception => exception
+        rescue => exception
 
           # Log error and return nil if the session can't be parsed
           #
@@ -337,7 +337,7 @@ module Hoodoo
             return :not_found
           end
 
-        rescue Exception => exception
+        rescue => exception
 
           # Log error and return nil if the session can't be parsed
           #
@@ -566,16 +566,16 @@ module Hoodoo
 
           stats = @@dalli_clients[ host ].stats()
 
-        rescue Exception => e
+        rescue => e
           exception = e
 
         end
 
         if stats.nil?
-          if ( exception )
-            raise "Hoodoo::Services::Session.connect_to_memcached: Cannot connect to Memcached at '#{ host }': #{ exception.to_s }"
-          else
+          if exception.nil?
             raise "Hoodoo::Services::Session.connect_to_memcached: Did not get back meaningful data from Memcached at '#{ host }'"
+          else
+            raise "Hoodoo::Services::Session.connect_to_memcached: Cannot connect to Memcached at '#{ host }': #{ exception.to_s }"
           end
         else
           return @@dalli_clients[ host ]


### PR DESCRIPTION
Via @thelollies who pointed out this was happening in the Session module when reviewing a recent PR.