### PR TITLE
Logging improvements

### DIFF
--- a/lib/hoodoo/services/middleware/amqp_log_writer.rb
+++ b/lib/hoodoo/services/middleware/amqp_log_writer.rb
@@ -67,10 +67,9 @@ module Hoodoo; module Services
 
         # Take care with Symbol keys in 'data' vs string keys in e.g. 'session'.
 
-        uuid    = data[ :id      ] || Hoodoo::UUID.generate()
         session = data[ :session ] || {}
         message = {
-          :id                   => uuid,
+          :id                   => data[ :id ],
           :level                => level,
           :component            => component,
           :code                 => code,

--- a/lib/hoodoo/services/middleware/amqp_log_writer.rb
+++ b/lib/hoodoo/services/middleware/amqp_log_writer.rb
@@ -65,25 +65,23 @@ module Hoodoo; module Services
       def report( level, component, code, data )
         return if @alchemy.nil?
 
-        # Take care with Symbol keys in 'data' vs string keys in e.g. 'Session'.
+        # Take care with Symbol keys in 'data' vs string keys in e.g. 'session'.
 
-        data[ :id ] ||= Hoodoo::UUID.generate()
-
+        uuid    = data[ :id      ] || Hoodoo::UUID.generate()
         session = data[ :session ] || {}
         message = {
+          :id                   => uuid,
+          :level                => level,
+          :component            => component,
+          :code                 => code,
+          :reported_at          => Time.now.iso8601( 12 ),
 
-          :id             => data[ :id ],
-          :level          => level,
-          :component      => component,
-          :code           => code,
-          :reported_at    => Time.now.iso8601( 12 ),
+          :interaction_id       => data[ :interaction_id ],
+          :data                 => data,
 
-          :data           => data,
-
-          :interaction_id => data[ :interaction_id ],
-          :caller_id      => session[ 'caller_id' ],
-          :identity       => ( session[ 'identity' ] || {} ).to_h
-
+          :caller_id            => session[ 'caller_id'            ],
+          :caller_identity_name => session[ 'caller_identity_name' ],
+          :identity             => ( session[ 'identity' ] || {} ).to_h
         }.to_json()
 
         @alchemy.send_message_to_service( @routing_key, { "body" => message } )

--- a/lib/hoodoo/services/middleware/middleware.rb
+++ b/lib/hoodoo/services/middleware/middleware.rb
@@ -1080,6 +1080,7 @@ module Hoodoo; module Services
       action    = interaction.requested_action
 
       data = {
+        :id             => Hoodoo::UUID.generate(),
         :interaction_id => interaction.interaction_id
       }
 
@@ -1309,7 +1310,9 @@ module Hoodoo; module Services
             # persistence layers store the item as an error with the correct ID.
 
             body = ::JSON.parse( body )
-            data[ :id ] = body[ 'id' ]
+
+            uuid = body[ 'id' ]
+            data[ :id ] = uuid unless uuid.nil?
           rescue
           end
 

--- a/lib/hoodoo/services/services/session.rb
+++ b/lib/hoodoo/services/services/session.rb
@@ -32,6 +32,14 @@ module Hoodoo
       #
       attr_accessor :caller_id
 
+      # An optional property of a session is the Caller's "identity name",
+      # a generic way to refer to this Caller which will appear in logs.
+      # The use is up to the session creator, in combination with whatever
+      # logging engine is in use; if it ascribes meaning to the identity
+      # name, then the session creator must ensure it comforms.
+      #
+      attr_accessor :caller_identity_name
+
       # Callers can change; if so, related sessions must be invalidated.
       # This must be achieved by keeping a version count on the Caller. A
       # session is associated with a particular Caller version and if the
@@ -376,6 +384,7 @@ module Hoodoo
           session_id
           caller_id
           caller_version
+          caller_identity_name
 
         ).each do | property |
           value = self.send( property )
@@ -420,6 +429,7 @@ module Hoodoo
           session_id
           caller_id
           caller_version
+          caller_identity_name
 
         ).each do | property |
           value = hash[ property ]


### PR DESCRIPTION
Introduces a "verbose" option for logging (default off, omits heavy duty sections of the session information) and includes field `caller_identity_name`, a generic scoping name concept from Alchemy.

* Refactored to always generate the UUID in `id` at logging source rather than only in the Alchemy writer, so it's consistent across all log sinks.
* Common log payload data generation refactored into private middleware method `build_common_log_data_for`.

Note subtle arising fix in AMQP log writer where it used to force a value into `data`, but that Hash is passed by reference; so if any other loggers were in the pool afterwards, they'd acquire the value, but loggers in the queue beforehand would not see it.