### PR TITLE
Add a 'respond_to?' check for the cross-application tracing patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.1 (2016-04-18)
+
+* NewRelic cross-application tracing patch does one extra check on availability of a method before enabling itself. This stops service code having to work around edge cases in e.g. migration files, where parts of Hoodoo get included and the monkey patch activates but other parts haven't been included and the patch doesn't see what it expects (https://github.com/LoyaltyNZ/hoodoo/pull/164).
+
 ## 1.8.0 (2016-04-13)
 
 * New `Hoodoo::Monkey` engine for official monkey patching. NewRelic cross-application tracing for on-queue inter-resource calls makes use of this mechanism and there are likely to be more to come. The module may be useful for various applications outside the core Hoodoo remit of API services (https://github.com/LoyaltyNZ/hoodoo/pull/162).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    hoodoo (1.8.0)
+    hoodoo (1.8.1)
       dalli (~> 2.7)
       kgio (~> 2.9)
 

--- a/docs/rdoc/classes/Hoodoo.html
+++ b/docs/rdoc/classes/Hoodoo.html
@@ -1240,7 +1240,7 @@ thing.</p>
           <tr valign='top' id='VERSION'>
             <td class="attr-name">VERSION</td>
             <td>=</td>
-            <td class="attr-value"><pre>&#39;1.8.0&#39;</pre></td>
+            <td class="attr-value"><pre>&#39;1.8.1&#39;</pre></td>
           </tr>
             <tr valign='top'>
               <td>&nbsp;</td>

--- a/docs/rdoc/created.rid
+++ b/docs/rdoc/created.rid
@@ -1,4 +1,4 @@
-Wed, 13 Apr 2016 14:58:42 +1200
+Mon, 18 Apr 2016 14:46:49 +1200
 README.md	Thu, 14 Jan 2016 15:40:47 +1300
 lib/hoodoo.rb	Wed, 13 Apr 2016 14:55:13 +1200
 lib/hoodoo/active.rb	Mon, 15 Feb 2016 10:21:55 +1300
@@ -58,7 +58,7 @@ lib/hoodoo/logger/writers/stream_writer.rb	Thu, 14 Jan 2016 15:15:01 +1300
 lib/hoodoo/middleware.rb	Wed, 02 Mar 2016 15:41:21 +1300
 lib/hoodoo/monkey.rb	Wed, 13 Apr 2016 14:55:13 +1200
 lib/hoodoo/monkey/monkey.rb	Wed, 13 Apr 2016 14:55:13 +1200
-lib/hoodoo/monkey/patch/newrelic_traced_amqp.rb	Wed, 13 Apr 2016 14:55:13 +1200
+lib/hoodoo/monkey/patch/newrelic_traced_amqp.rb	Mon, 18 Apr 2016 14:42:28 +1200
 lib/hoodoo/presenters.rb	Thu, 14 Jan 2016 15:15:01 +1300
 lib/hoodoo/presenters/base.rb	Thu, 14 Jan 2016 15:15:01 +1300
 lib/hoodoo/presenters/base_dsl.rb	Thu, 14 Jan 2016 15:15:01 +1300
@@ -112,4 +112,4 @@ lib/hoodoo/utilities.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/utilities/string_inquirer.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/utilities/utilities.rb	Thu, 24 Mar 2016 14:34:33 +1300
 lib/hoodoo/utilities/uuid.rb	Wed, 02 Mar 2016 15:18:24 +1300
-lib/hoodoo/version.rb	Wed, 13 Apr 2016 14:57:50 +1200
+lib/hoodoo/version.rb	Mon, 18 Apr 2016 14:46:07 +1200

--- a/hoodoo.gemspec
+++ b/hoodoo.gemspec
@@ -4,7 +4,7 @@ require 'hoodoo/version'
 Gem::Specification.new do | s |
   s.name        = 'hoodoo'
   s.version     = Hoodoo::VERSION
-  s.date        = '2016-04-13'
+  s.date        = '2016-04-18'
   s.summary     = 'Opinionated APIs'
   s.description = 'Simplify the implementation of consistent services within an API-based software platform.'
   s.authors     = [ 'Loyalty New Zealand' ]

--- a/lib/hoodoo/monkey/patch/newrelic_traced_amqp.rb
+++ b/lib/hoodoo/monkey/patch/newrelic_traced_amqp.rb
@@ -179,7 +179,8 @@ module Hoodoo
           )
 
           if defined?( Hoodoo::Services ) &&
-             defined?( Hoodoo::Services::Middleware) &&
+             defined?( Hoodoo::Services::Middleware ) &&
+             Hoodoo::Services::Middleware.respond_to?( :environment ) &&
              Hoodoo::Services::Middleware.environment.production? != true
 
             Hoodoo::Monkey.enable( extension_module: Hoodoo::Monkey::Patch::NewRelicTracedAMQP )

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -12,6 +12,6 @@ module Hoodoo
   # The Hoodoo gem version. If this changes, ensure that the date in
   # "hoodoo.gemspec" is correct and run "bundle install" (or "update").
   #
-  VERSION = '1.8.0'
+  VERSION = '1.8.1'
 
 end


### PR DESCRIPTION
Under edge case conditions such as a service ActiveRecord migration that required 'hoodoo/active', the patch might get invoked but full middleware would not be available. No spec coverage for the 'negative' case because if undefined it simply won't proceed, but the line is run in the 'positive' case as part of the existing test coverage.