### PR TITLE
Rearrange API documentation for Release 3

### DIFF
--- a/docs/utilities/add_toc.rb
+++ b/docs/utilities/add_toc.rb
@@ -20,7 +20,7 @@ paths = []
 
 args = if ARGV.empty?
   [
-    'api_specification.md'
+    '../api_specification/README.md'
   ] # Add other docs to this array if required
 else
   ARGV


### PR DESCRIPTION
…(and fix default path in `add_doc.rb` in passing).

GitHub seems to be having trouble with the diff, but as far as I can tell the GFM syntax is valid.