### PR TITLE
Feature/analytics streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.0 (2016-09-23)
+
+* The AMQP log writer back-end ([`Hoodoo::Services::Middleware::AMQPLogWriter`](https://cdn.rawgit.com/LoyaltyNZ/hoodoo/master/docs/rdoc/classes/Hoodoo/Services/Middleware/AMQPLogWriter.html)) now allows an alternative routing key to be defined via environment variable `AMQ_ANALYTICS_LOGGING_ENDPOINT`. The default routing key is (still) `platform.logging`, overridden by environment variable `AMQ_LOGGING_ENDPOINT` or by the AMQP log writer being instantiated with an explicit override routing key parameter, as before; however, the additional new environment variable allows, specifically, log data with a code of `analytics` to be sent to a different queue. This means log messages can be "tagged" as for analytical purposes (of some domain defined by the entity creating the software making the log calls) via a code of `analytics` and either left mixed in with all the other log data on the default routing key, or pushed out into its own stream for special case use - e.g. higher or lower priority examination by log data sinks. Only log data with a code (as String or Symbol) of `analytics` is sent via the alternative routing key, assuming one is defined. All other log data is unaffected.
+
 ## 1.9.2 (2016-08-29)
 
 * The de-duplication pass for URI query strings would accidentally de-duplicate legitimate duplication strings such as `...?sort=name,created_at&direction=desc,desc` causing incorrect 422 errors. Fixed.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    hoodoo (1.9.2)
+    hoodoo (1.10.0)
       dalli (~> 2.7)
       kgio (~> 2.9)
 
@@ -67,7 +67,7 @@ GEM
     minitest (5.9.0)
     multi_json (1.12.1)
     multi_xml (0.5.5)
-    pg (0.18.4)
+    pg (0.19.0)
     rack (2.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -82,7 +82,7 @@ GEM
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
       rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.2)
+    rspec-core (3.5.3)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)

--- a/docs/rdoc/classes/Hoodoo.html
+++ b/docs/rdoc/classes/Hoodoo.html
@@ -1241,7 +1241,7 @@ thing.</p>
           <tr valign='top' id='VERSION'>
             <td class="attr-name">VERSION</td>
             <td>=</td>
-            <td class="attr-value"><pre>&#39;1.9.2&#39;</pre></td>
+            <td class="attr-value"><pre>&#39;1.10.0&#39;</pre></td>
           </tr>
             <tr valign='top'>
               <td>&nbsp;</td>

--- a/docs/rdoc/classes/Hoodoo/Services/Middleware/AMQPLogWriter.html
+++ b/docs/rdoc/classes/Hoodoo/Services/Middleware/AMQPLogWriter.html
@@ -108,6 +108,13 @@ that&#39;s the AlchemyFlux::Service instance handling queue communication.
 This is assigned to the <code>alchemy</code> parameter. The logger will
 then use this active Alchemy service to send messages to its configured
 routing key.</p>
+
+<p>If +ENV[ &#39;AMQ_ANALYTICS_LOGGING_ENDPOINT&#39; ]+ is defined then its
+value will be used for a routing key in the case, very specifically, of a
+message logged with a <code>code</code> of <code>analytics</code>. If the
+variable is not set, the same routing key is used for all messages
+regardless of code; else that particular code can be streamed off to
+another Rabbit queue via the given alternative routing key.</p>
             </div>
 
 
@@ -118,10 +125,15 @@ routing key.</p>
                 <a href="javascript:toggleSource('method-c-new_source')" id="l_method-c-new_source">show</a>
               </p>
               <div id="method-c-new_source" class="dyn-source">
-                <pre><span class="ruby-comment"># File lib/hoodoo/services/middleware/amqp_log_writer.rb, line 40</span>
+                <pre><span class="ruby-comment"># File lib/hoodoo/services/middleware/amqp_log_writer.rb, line 47</span>
 <span class="ruby-keyword">def</span> <span class="ruby-keyword ruby-title">initialize</span>( <span class="ruby-identifier">alchemy</span>, <span class="ruby-identifier">routing_key</span> = <span class="ruby-keyword">nil</span> )
-  <span class="ruby-ivar">@alchemy</span>     = <span class="ruby-identifier">alchemy</span>
-  <span class="ruby-ivar">@routing_key</span> = <span class="ruby-identifier">routing_key</span> <span class="ruby-operator">||</span> <span class="ruby-constant">ENV</span>[ <span class="ruby-string">&#39;AMQ_LOGGING_ENDPOINT&#39;</span> ] <span class="ruby-operator">||</span> <span class="ruby-string">&#39;platform.logging&#39;</span>
+  <span class="ruby-identifier">routing_key</span>           = <span class="ruby-identifier">routing_key</span> <span class="ruby-operator">||</span> <span class="ruby-constant">ENV</span>[ <span class="ruby-string">&#39;AMQ_LOGGING_ENDPOINT&#39;</span> ] <span class="ruby-operator">||</span> <span class="ruby-string">&#39;platform.logging&#39;</span>
+  <span class="ruby-identifier">analytics_routing_key</span> = <span class="ruby-constant">ENV</span>[ <span class="ruby-string">&#39;AMQ_ANALYTICS_LOGGING_ENDPOINT&#39;</span> ]
+
+  <span class="ruby-ivar">@alchemy</span>      = <span class="ruby-identifier">alchemy</span>
+  <span class="ruby-ivar">@routing_keys</span> = <span class="ruby-constant">Hash</span>.<span class="ruby-identifier">new</span>( <span class="ruby-identifier">routing_key</span> ) <span class="ruby-comment"># Use &quot;routing_key&quot; as a default value</span>
+
+  <span class="ruby-ivar">@routing_keys</span>[ <span class="ruby-value">:analytics</span> ] = <span class="ruby-identifier">analytics_routing_key</span> <span class="ruby-operator">||</span> <span class="ruby-identifier">routing_key</span>
 <span class="ruby-keyword">end</span></pre>
               </div>
             </div>
@@ -169,7 +181,7 @@ independent, searchable field in the log payload.</p>
                 <a href="javascript:toggleSource('method-i-report_source')" id="l_method-i-report_source">show</a>
               </p>
               <div id="method-i-report_source" class="dyn-source">
-                <pre><span class="ruby-comment"># File lib/hoodoo/services/middleware/amqp_log_writer.rb, line 65</span>
+                <pre><span class="ruby-comment"># File lib/hoodoo/services/middleware/amqp_log_writer.rb, line 77</span>
 <span class="ruby-keyword">def</span> <span class="ruby-keyword ruby-title">report</span>( <span class="ruby-identifier">level</span>, <span class="ruby-identifier">component</span>, <span class="ruby-identifier">code</span>, <span class="ruby-identifier">data</span> )
   <span class="ruby-keyword">return</span> <span class="ruby-keyword">if</span> <span class="ruby-ivar">@alchemy</span>.<span class="ruby-identifier">nil?</span>
 
@@ -191,7 +203,10 @@ independent, searchable field in the log payload.</p>
     <span class="ruby-value">:identity</span>             =<span class="ruby-operator">&gt;</span> ( <span class="ruby-identifier">session</span>[ <span class="ruby-string">&#39;identity&#39;</span> ] <span class="ruby-operator">||</span> {} ).<span class="ruby-identifier">to_h</span>
   }.<span class="ruby-identifier">to_json</span>()
 
-  <span class="ruby-ivar">@alchemy</span>.<span class="ruby-identifier">send_message_to_service</span>( <span class="ruby-ivar">@routing_key</span>, { <span class="ruby-string">&quot;body&quot;</span> =<span class="ruby-operator">&gt;</span> <span class="ruby-identifier">message</span> } )
+  <span class="ruby-ivar">@alchemy</span>.<span class="ruby-identifier">send_message_to_service</span>(
+    <span class="ruby-ivar">@routing_keys</span>[ <span class="ruby-identifier">code</span>.<span class="ruby-identifier">to_sym</span> ],
+    { <span class="ruby-string">&quot;body&quot;</span> =<span class="ruby-operator">&gt;</span> <span class="ruby-identifier">message</span> }
+  )
 <span class="ruby-keyword">end</span></pre>
               </div>
             </div>

--- a/docs/rdoc/classes/Hoodoo/Services/Middleware/AMQPLogWriter.html
+++ b/docs/rdoc/classes/Hoodoo/Services/Middleware/AMQPLogWriter.html
@@ -95,8 +95,8 @@ Thread for this logger.</p>
 <p>The Alchemy endpoint to use for sending messages to the AMQP-based queue.</p>
 </dd><dt><code>routing_key</code>
 <dd>
-<p>The routing key (as a String) to use. Optional. If omitted, reads +ENV[
-&#39;AMQ_LOGGING_ENDPOINT&#39; ]+ or if that is unset, defaults to
+<p>The routing key (as a String) to use. Optional. If omitted, reads
+<code>ENV['AMQ_LOGGING_ENDPOINT']</code> or if that is unset, defaults to
 <code>platform.logging</code>.</p>
 </dd></dl>
 
@@ -109,8 +109,8 @@ This is assigned to the <code>alchemy</code> parameter. The logger will
 then use this active Alchemy service to send messages to its configured
 routing key.</p>
 
-<p>If +ENV[ &#39;AMQ_ANALYTICS_LOGGING_ENDPOINT&#39; ]+ is defined then its
-value will be used for a routing key in the case, very specifically, of a
+<p>If <code>ENV['AMQ_ANALYTICS_LOGGING_ENDPOINT']</code> is defined then its
+value is used for a routing key in the case, very specifically, of a
 message logged with a <code>code</code> of <code>analytics</code>. If the
 variable is not set, the same routing key is used for all messages
 regardless of code; else that particular code can be streamed off to

--- a/docs/rdoc/created.rid
+++ b/docs/rdoc/created.rid
@@ -1,4 +1,4 @@
-Mon, 29 Aug 2016 13:55:15 +1200
+Fri, 23 Sep 2016 15:43:35 +1200
 README.md	Thu, 14 Jan 2016 15:40:47 +1300
 lib/hoodoo.rb	Wed, 13 Apr 2016 14:55:13 +1200
 lib/hoodoo/active.rb	Mon, 15 Feb 2016 10:21:55 +1300
@@ -14,7 +14,7 @@ lib/hoodoo/active/active_record/secure.rb	Mon, 15 Feb 2016 10:21:55 +1300
 lib/hoodoo/active/active_record/support.rb	Mon, 15 Feb 2016 10:21:55 +1300
 lib/hoodoo/active/active_record/translated.rb	Mon, 15 Feb 2016 10:21:55 +1300
 lib/hoodoo/active/active_record/uuid.rb	Thu, 18 Feb 2016 14:26:51 +1300
-lib/hoodoo/active/active_record/writer.rb	Mon, 29 Aug 2016 11:21:11 +1200
+lib/hoodoo/active/active_record/writer.rb	Tue, 30 Aug 2016 11:10:22 +1200
 lib/hoodoo/client.rb	Tue, 12 Apr 2016 14:16:20 +1200
 lib/hoodoo/client/augmented_array.rb	Wed, 06 Apr 2016 13:08:41 +1200
 lib/hoodoo/client/augmented_base.rb	Thu, 14 Jan 2016 15:15:01 +1300
@@ -91,7 +91,7 @@ lib/hoodoo/services/discovery/results/for_amqp.rb	Tue, 26 Jan 2016 14:26:24 +130
 lib/hoodoo/services/discovery/results/for_http.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/services/discovery/results/for_local.rb	Tue, 26 Jan 2016 14:26:24 +1300
 lib/hoodoo/services/discovery/results/for_remote.rb	Thu, 14 Jan 2016 15:15:02 +1300
-lib/hoodoo/services/middleware/amqp_log_writer.rb	Tue, 29 Mar 2016 11:38:09 +1300
+lib/hoodoo/services/middleware/amqp_log_writer.rb	Fri, 23 Sep 2016 15:35:28 +1200
 lib/hoodoo/services/middleware/endpoints/inter_resource_local.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/services/middleware/endpoints/inter_resource_remote.rb	Fri, 29 Jan 2016 15:42:39 +1300
 lib/hoodoo/services/middleware/exception_reporting/base_reporter.rb	Thu, 18 Feb 2016 14:26:51 +1300
@@ -99,7 +99,7 @@ lib/hoodoo/services/middleware/exception_reporting/exception_reporting.rb	Thu, 1
 lib/hoodoo/services/middleware/exception_reporting/reporters/airbrake_reporter.rb	Thu, 18 Feb 2016 09:28:54 +1300
 lib/hoodoo/services/middleware/exception_reporting/reporters/raygun_reporter.rb	Thu, 18 Feb 2016 09:28:54 +1300
 lib/hoodoo/services/middleware/interaction.rb	Thu, 24 Mar 2016 14:34:33 +1300
-lib/hoodoo/services/middleware/middleware.rb	Mon, 29 Aug 2016 13:25:59 +1200
+lib/hoodoo/services/middleware/middleware.rb	Tue, 30 Aug 2016 11:10:22 +1200
 lib/hoodoo/services/middleware/rack_monkey_patch.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/services/services/context.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/services/services/implementation.rb	Thu, 14 Jan 2016 15:15:02 +1300
@@ -113,4 +113,4 @@ lib/hoodoo/utilities.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/utilities/string_inquirer.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/utilities/utilities.rb	Thu, 24 Mar 2016 14:34:33 +1300
 lib/hoodoo/utilities/uuid.rb	Wed, 02 Mar 2016 15:18:24 +1300
-lib/hoodoo/version.rb	Mon, 29 Aug 2016 13:54:55 +1200
+lib/hoodoo/version.rb	Fri, 23 Sep 2016 15:42:03 +1200

--- a/docs/rdoc/created.rid
+++ b/docs/rdoc/created.rid
@@ -1,4 +1,4 @@
-Fri, 23 Sep 2016 15:43:35 +1200
+Fri, 23 Sep 2016 15:45:45 +1200
 README.md	Thu, 14 Jan 2016 15:40:47 +1300
 lib/hoodoo.rb	Wed, 13 Apr 2016 14:55:13 +1200
 lib/hoodoo/active.rb	Mon, 15 Feb 2016 10:21:55 +1300
@@ -91,7 +91,7 @@ lib/hoodoo/services/discovery/results/for_amqp.rb	Tue, 26 Jan 2016 14:26:24 +130
 lib/hoodoo/services/discovery/results/for_http.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/services/discovery/results/for_local.rb	Tue, 26 Jan 2016 14:26:24 +1300
 lib/hoodoo/services/discovery/results/for_remote.rb	Thu, 14 Jan 2016 15:15:02 +1300
-lib/hoodoo/services/middleware/amqp_log_writer.rb	Fri, 23 Sep 2016 15:35:28 +1200
+lib/hoodoo/services/middleware/amqp_log_writer.rb	Fri, 23 Sep 2016 15:45:40 +1200
 lib/hoodoo/services/middleware/endpoints/inter_resource_local.rb	Thu, 14 Jan 2016 15:15:02 +1300
 lib/hoodoo/services/middleware/endpoints/inter_resource_remote.rb	Fri, 29 Jan 2016 15:42:39 +1300
 lib/hoodoo/services/middleware/exception_reporting/base_reporter.rb	Thu, 18 Feb 2016 14:26:51 +1300

--- a/hoodoo.gemspec
+++ b/hoodoo.gemspec
@@ -4,7 +4,7 @@ require 'hoodoo/version'
 Gem::Specification.new do | s |
   s.name        = 'hoodoo'
   s.version     = Hoodoo::VERSION
-  s.date        = '2016-08-29'
+  s.date        = '2016-09-23'
   s.summary     = 'Opinionated APIs'
   s.description = 'Simplify the implementation of consistent services within an API-based software platform.'
   s.authors     = [ 'Loyalty New Zealand' ]

--- a/lib/hoodoo/services/middleware/amqp_log_writer.rb
+++ b/lib/hoodoo/services/middleware/amqp_log_writer.rb
@@ -27,8 +27,8 @@ module Hoodoo; module Services
       #                 AMQP-based queue.
       #
       # +routing_key+:: The routing key (as a String) to use. Optional. If
-      #                 omitted, reads +ENV[ 'AMQ_LOGGING_ENDPOINT' ]+ or if
-      #                 that is unset, defaults to +platform.logging+.
+      #                 omitted, reads <tt>ENV['AMQ_LOGGING_ENDPOINT']</tt> or
+      #                 if that is unset, defaults to +platform.logging+.
       #
       # If you're running with Rack on top of Alchemy, then the +call+ method's
       # +env+ parameter containing the Rack environment _MUST_ have a key of
@@ -37,8 +37,8 @@ module Hoodoo; module Services
       # parameter. The logger will then use this active Alchemy service to send
       # messages to its configured routing key.
       #
-      # If +ENV[ 'AMQ_ANALYTICS_LOGGING_ENDPOINT' ]+ is defined then its value
-      # will be used for a routing key in the case, very specifically, of a
+      # If <tt>ENV['AMQ_ANALYTICS_LOGGING_ENDPOINT']</tt> is defined then its
+      # value is used for a routing key in the case, very specifically, of a
       # message logged with a +code+ of +analytics+. If the variable is not set,
       # the same routing key is used for all messages regardless of code; else
       # that particular code can be streamed off to another Rabbit queue via the

--- a/lib/hoodoo/services/middleware/amqp_log_writer.rb
+++ b/lib/hoodoo/services/middleware/amqp_log_writer.rb
@@ -37,9 +37,21 @@ module Hoodoo; module Services
       # parameter. The logger will then use this active Alchemy service to send
       # messages to its configured routing key.
       #
+      # If +ENV[ 'AMQ_ANALYTICS_LOGGING_ENDPOINT' ]+ is defined then its value
+      # will be used for a routing key in the case, very specifically, of a
+      # message logged with a +code+ of +analytics+. If the variable is not set,
+      # the same routing key is used for all messages regardless of code; else
+      # that particular code can be streamed off to another Rabbit queue via the
+      # given alternative routing key.
+      #
       def initialize( alchemy, routing_key = nil )
-        @alchemy     = alchemy
-        @routing_key = routing_key || ENV[ 'AMQ_LOGGING_ENDPOINT' ] || 'platform.logging'
+        routing_key           = routing_key || ENV[ 'AMQ_LOGGING_ENDPOINT' ] || 'platform.logging'
+        analytics_routing_key = ENV[ 'AMQ_ANALYTICS_LOGGING_ENDPOINT' ]
+
+        @alchemy      = alchemy
+        @routing_keys = Hash.new( routing_key ) # Use "routing_key" as a default value
+
+        @routing_keys[ :analytics ] = analytics_routing_key || routing_key
       end
 
       # Custom implementation of the Hoodoo::Logger::WriterMixin#report
@@ -83,7 +95,10 @@ module Hoodoo; module Services
           :identity             => ( session[ 'identity' ] || {} ).to_h
         }.to_json()
 
-        @alchemy.send_message_to_service( @routing_key, { "body" => message } )
+        @alchemy.send_message_to_service(
+          @routing_keys[ code.to_sym ],
+          { "body" => message }
+        )
       end
     end
 

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -12,6 +12,6 @@ module Hoodoo
   # The Hoodoo gem version. If this changes, ensure that the date in
   # "hoodoo.gemspec" is correct and run "bundle install" (or "update").
   #
-  VERSION = '1.9.2'
+  VERSION = '1.10.0'
 
 end

--- a/spec/services/middleware/amqp_log_writer_spec.rb
+++ b/spec/services/middleware/amqp_log_writer_spec.rb
@@ -63,7 +63,6 @@ describe Hoodoo::Services::Middleware::AMQPLogWriter do
     Timecop.freeze do
       level          = 'warn'
       component      = 'test_component'
-      code           = 'analytics'
       reported_at    = Time.now.iso8601( 12 )
       id             = Hoodoo::UUID.generate
       interaction_id = Hoodoo::UUID.generate


### PR DESCRIPTION
Allow the AMQP log writing back-end to send log data reported with a code of "analytics" to (optionally) a different routing key from normal log data. This facilitates a specialised stream of data for downstream analysis on its own queue that might have different levels of prioritisation, monitoring or different sink software compared with the normal log stream.