### PR TITLE
Feature/created after

### DIFF
--- a/lib/hoodoo/active/active_record/finder.rb
+++ b/lib/hoodoo/active/active_record/finder.rb
@@ -20,8 +20,8 @@ module Hoodoo
     #
     # It is _STRONGLY_ _RECOMMENDED_ that you use the likes of:
     #
-    # * Hoodoo::ActiveRecord::Finder::ClassMethods::acquire_in
-    # * Hoodoo::ActiveRecord::Finder::ClassMethods::list_in
+    # * Hoodoo::ActiveRecord::Finder::ClassMethods#acquire_in
+    # * Hoodoo::ActiveRecord::Finder::ClassMethods#list_in
     #
     # ...to retrieve model data related to resource instances and participate
     # "for free" in whatever plug-in ActiveRecord modules are mixed into the

--- a/lib/hoodoo/active/active_record/finder.rb
+++ b/lib/hoodoo/active/active_record/finder.rb
@@ -428,20 +428,14 @@ module Hoodoo
           finder = all.offset( list_parameters.offset ).limit( list_parameters.limit )
           finder = finder.order( list_parameters.sort_data )
 
-          # DRY up the 'each' loops below. Use a Proc not a method because any
-          # methods we define will end up being defined on the including Model,
-          # increasing the chance of a name collision.
-          #
-          dry_proc = Proc.new do | data, attr, proc |
-            value = data[ attr ]
-            proc.call( attr, value ) unless value.nil?
-          end
-
           search_map = self.nz_co_loyalty_hoodoo_search_with
 
           unless search_map.nil?
-            search_map.each do | attr, proc |
-              args   = dry_proc.call( list_parameters.search_data, attr, proc )
+            search_map.each do | attr, finder_args_proc |
+              value = list_parameters.search_data[ attr ]
+              next if value.nil?
+
+              args   = finder_args_proc.call( attr, value )
               finder = finder.where( *args ) unless args.nil?
             end
           end
@@ -449,8 +443,11 @@ module Hoodoo
           filter_map = self.nz_co_loyalty_hoodoo_filter_with
 
           unless filter_map.nil?
-            filter_map.each do | attr, proc |
-              args   = dry_proc.call( list_parameters.filter_data, attr, proc )
+            filter_map.each do | attr, finder_args_proc |
+              value = list_parameters.filter_data[ attr ]
+              next if value.nil?
+
+              args   = finder_args_proc.call( attr, value )
               finder = finder.where.not( *args ) unless args.nil?
             end
           end
@@ -714,7 +711,8 @@ module Hoodoo
         #         which assist with filling in non-nil values for this Hash.
         #
         def search_with( hash )
-          self.nz_co_loyalty_hoodoo_search_with = Hoodoo::ActiveRecord::Support.process_to_map( hash )
+          self.nz_co_loyalty_hoodoo_search_with ||= Hoodoo::ActiveRecord::Support.framework_search_and_filter_data()
+          self.nz_co_loyalty_hoodoo_search_with.merge!( Hoodoo::ActiveRecord::Support.process_to_map( hash ) )
         end
 
         # As #search_with, but used in +where.not+ queries.
@@ -735,7 +733,8 @@ module Hoodoo
         # +map+:: As #search_with.
         #
         def filter_with( hash )
-          self.nz_co_loyalty_hoodoo_filter_with = Hoodoo::ActiveRecord::Support.process_to_map( hash )
+          self.nz_co_loyalty_hoodoo_filter_with ||= Hoodoo::ActiveRecord::Support.framework_search_and_filter_data()
+          self.nz_co_loyalty_hoodoo_filter_with.merge!( Hoodoo::ActiveRecord::Support.process_to_map( hash ) )
         end
 
         # Deprecated interface replaced by #acquire. Instead of:

--- a/lib/hoodoo/active/active_record/search_helper.rb
+++ b/lib/hoodoo/active/active_record/search_helper.rb
@@ -48,7 +48,7 @@ module Hoodoo
         # will be case sensitive only if your database is configured for
         # case sensitive matching by default.
         #
-        # Results in a <tt>foo = bar</tt> query.
+        # Results in a <tt>foo = bar AND foo IS NOT NULL</tt> query.
         #
         # +model_field_name+:: If the model attribute name differs from the
         #                      search key you want to use in the URI, give
@@ -70,7 +70,8 @@ module Hoodoo
         # which are split into an array then processed by AREL back to
         # something SQL-safe.
         #
-        # Results in a <tt>foo IN bar,baz,boo</tt> query.
+        # Results in a <tt>foo IN (bar,baz,boo) AND foo IS NOT NULL</tt>
+        # query.
         #
         # +model_field_name+:: If the model attribute name differs from the
         #                      search key you want to use in the URI, give
@@ -94,7 +95,8 @@ module Hoodoo
         # use cases for this are quite unusual; you probably want to use
         # #cs_match_csv most of the time.
         #
-        # Results in a <tt>foo IN bar,baz,boo</tt> query.
+        # Results in a <tt>foo IN (bar,baz,boo) AND foo IS NOT NULL</tt>
+        # query.
         #
         # +model_field_name+:: If the model attribute name differs from the
         #                      search key you want to use in the URI, give
@@ -116,6 +118,8 @@ module Hoodoo
         # As #cs_match, but adds wildcards at the front and end of the string
         # for a case-sensitive-all-wildcard match.
         #
+        # Results in a <tt>foo LIKE bar AND foo IS NOT NULL</tt> query.
+        #
         def self.csaw_match( model_field_name = nil )
           Proc.new { | attr, value |
             column = model_field_name || attr
@@ -130,8 +134,9 @@ module Hoodoo
         # PostgreSQL, consider using the faster #ci_match_postgres method
         # instead.
         #
-        # Results in a <tt>lower(foo) = bar</tt> query with +bar+ coerced to
-        # a String and converted to lower case by Ruby first.
+        # Results in a <tt>lower(foo) = bar AND foo IS NOT NULL</tt> query
+        # with +bar+ coerced to a String and converted to lower case by Ruby
+        # first.
         #
         # +model_field_name+:: If the model attribute name differs from the
         #                      search key you want to use in the URI, give
@@ -153,6 +158,8 @@ module Hoodoo
         # As #ci_match_generic, but adds wildcards at the front and end of
         # the string for a case-insensitive-all-wildcard match.
         #
+        # Results in a <tt>foo LIKE %bar% AND foo IS NOT NULL</tt> query.
+        #
         def self.ciaw_match_generic( model_field_name = nil )
           Proc.new { | attr, value |
             column = model_field_name || attr
@@ -166,7 +173,7 @@ module Hoodoo
         # quickly. If you need a database agnostic solution, consider using
         # the slower #ci_match_generic method instead.
         #
-        # Results in a <tt>foo ILIKE bar</tt> query.
+        # Results in a <tt>foo ILIKE bar AND foo IS NOT NULL</tt> query.
         #
         # +model_field_name+:: If the model attribute name differs from the
         #                      search key you want to use in the URI, give
@@ -187,6 +194,8 @@ module Hoodoo
         # As #ci_match_postgres, but adds wildcards at the front and end of
         # the string for a case-insensitive-all-wildcard match.
         #
+        # Results in a <tt>foo ILIKE %bar% AND foo IS NOT NULL</tt> query.
+        #
         def self.ciaw_match_postgres( model_field_name = nil )
           Proc.new { | attr, value |
             column = model_field_name || attr
@@ -194,8 +203,71 @@ module Hoodoo
             [ "#{ column } ILIKE ? AND #{ column } IS NOT NULL", "%#{ value }%" ]
           }
         end
-      end
 
+        # Case-sensitive less-than (default-style comparison). *WARNING:* This
+        # will be case sensitive only if your database is configured for
+        # case sensitive matching by default.
+        #
+        # If comparing non-string column types be sure to pass in a value of an
+        # appropriate matching type (e.g. compare dates with DateTimes), else
+        # returned results will be incorrect but errors may not arise depending
+        # on database engine in use.
+        #
+        # Results in a <tt>foo < bar AND foo IS NOT NULL</tt> query.
+        #
+        # +model_field_name+:: If the model attribute name differs from the
+        #                      search key you want to use in the URI, give
+        #                      the model attribute name here, else omit.
+        #
+        # Returns a value that can be asssigned to a URI query string key in
+        # the Hash given to Hoodoo::ActiveRecord::Finder#search_with or
+        # Hoodoo::ActiveRecord::Finder#filter_with.
+        #
+        def self.cs_lt( model_field_name = nil )
+          Proc.new { | attr, value |
+            column = model_field_name || attr
+
+            [ "#{ column } < ? AND #{ column } IS NOT NULL", value ]
+          }
+        end
+
+        # As #cs_lt, but compares with less-than-or-equal-to.
+        #
+        # Results in a <tt>foo <= bar AND foo IS NOT NULL</tt> query.
+        #
+        def self.cs_lte( model_field_name = nil )
+          Proc.new { | attr, value |
+            column = model_field_name || attr
+
+            [ "#{ column } <= ? AND #{ column } IS NOT NULL", value ]
+          }
+        end
+
+        # As #cs_lt, but compares with greater-than.
+        #
+        # Results in a <tt>foo > bar AND foo IS NOT NULL</tt> query.
+        #
+        def self.cs_gt( model_field_name = nil )
+          Proc.new { | attr, value |
+            column = model_field_name || attr
+
+            [ "#{ column } > ? AND #{ column } IS NOT NULL", value ]
+          }
+        end
+
+        # As #cs_lt, but compares with greater-than-or-equal-to.
+        #
+        # Results in a <tt>foo >= bar AND foo IS NOT NULL</tt> query.
+        #
+        def self.cs_gte( model_field_name = nil )
+          Proc.new { | attr, value |
+            column = model_field_name || attr
+
+            [ "#{ column } >= ? AND #{ column } IS NOT NULL", value ]
+          }
+        end
+
+      end
     end
   end
 end

--- a/lib/hoodoo/active/active_record/search_helper.rb
+++ b/lib/hoodoo/active/active_record/search_helper.rb
@@ -14,8 +14,9 @@ module Hoodoo
     module Finder
 
       # Help build up Hash maps to pass into Hoodoo::ActiveRecord::Finder
-      # methods Hoodoo::ActiveRecord::Finder#search_with and
-      # Hoodoo::ActiveRecord::Finder#filter_with.
+      # methods Hoodoo::ActiveRecord::Finder::ClassMethods#search_with and
+      # Hoodoo::ActiveRecord::Finder::ClassMethods#filter_with. Used also
+      # by the default framework search scopes.
       #
       # The usage pattern is as follows, using "sh" as a local variable
       # just for brevity - it isn't required:
@@ -31,7 +32,7 @@ module Hoodoo
       #     end
       #
       # The helper methods just provide values to pass into the Hash used
-      # with the search/fitler Hoodoo::ActiveRecord::Finder methods, so
+      # with the search/filter Hoodoo::ActiveRecord::Finder methods, so
       # they're optional and compatible with calls that write it out "by
       # hand".
       #
@@ -55,8 +56,9 @@ module Hoodoo
         #                      the model attribute name here, else omit.
         #
         # Returns a value that can be asssigned to a URI query string key in
-        # the Hash given to Hoodoo::ActiveRecord::Finder#search_with or
-        # Hoodoo::ActiveRecord::Finder#filter_with.
+        # the Hash given to
+        # Hoodoo::ActiveRecord::Finder::ClassMethods#search_with or
+        # Hoodoo::ActiveRecord::Finder::ClassMethods#filter_with.
         #
         def self.cs_match( model_field_name = nil )
           Proc.new { | attr, value |
@@ -78,8 +80,9 @@ module Hoodoo
         #                      the model attribute name here, else omit.
         #
         # Returns a value that can be asssigned to a URI query string key in
-        # the Hash given to Hoodoo::ActiveRecord::Finder#search_with or
-        # Hoodoo::ActiveRecord::Finder#filter_with.
+        # the Hash given to
+        # Hoodoo::ActiveRecord::Finder::ClassMethods#search_with or
+        # Hoodoo::ActiveRecord::Finder::ClassMethods#filter_with.
         #
         def self.cs_match_csv( model_field_name = nil )
           Proc.new { | attr, value |
@@ -93,7 +96,8 @@ module Hoodoo
         # Case-sensitive match of a series of values given as an Array.
         # Normally, query string information comes in as a String so the
         # use cases for this are quite unusual; you probably want to use
-        # #cs_match_csv most of the time.
+        # Hoodoo::ActiveRecord::Finder::SearchHelper::cs_match_csv most of
+        # the time.
         #
         # Results in a <tt>foo IN (bar,baz,boo) AND foo IS NOT NULL</tt>
         # query.
@@ -103,8 +107,9 @@ module Hoodoo
         #                      the model attribute name here, else omit.
         #
         # Returns a value that can be asssigned to a URI query string key in
-        # the Hash given to Hoodoo::ActiveRecord::Finder#search_with or
-        # Hoodoo::ActiveRecord::Finder#filter_with.
+        # the Hash given to
+        # Hoodoo::ActiveRecord::Finder::ClassMethods#search_with or
+        # Hoodoo::ActiveRecord::Finder::ClassMethods#filter_with.
         #
         def self.cs_match_array( model_field_name = nil )
           Proc.new { | attr, value |
@@ -115,8 +120,9 @@ module Hoodoo
           }
         end
 
-        # As #cs_match, but adds wildcards at the front and end of the string
-        # for a case-sensitive-all-wildcard match.
+        # As Hoodoo::ActiveRecord::Finder::SearchHelper::cs_match, but
+        # adds wildcards at the front and end of the string for a
+        # case-sensitive-all-wildcard match.
         #
         # Results in a <tt>foo LIKE bar AND foo IS NOT NULL</tt> query.
         #
@@ -131,7 +137,8 @@ module Hoodoo
 
         # Case-insensitive match which should be fairly database independent
         # but will run relatively slowly as a result. If you are using
-        # PostgreSQL, consider using the faster #ci_match_postgres method
+        # PostgreSQL, consider using the faster
+        # Hoodoo::ActiveRecord::Finder::SearchHelper::ci_match_postgres method
         # instead.
         #
         # Results in a <tt>lower(foo) = bar AND foo IS NOT NULL</tt> query
@@ -143,8 +150,9 @@ module Hoodoo
         #                      the model attribute name here, else omit.
         #
         # Returns a value that can be asssigned to a URI query string key in
-        # the Hash given to Hoodoo::ActiveRecord::Finder#search_with or
-        # Hoodoo::ActiveRecord::Finder#filter_with.
+        # the Hash given to
+        # Hoodoo::ActiveRecord::Finder::ClassMethods#search_with or
+        # Hoodoo::ActiveRecord::Finder::ClassMethods#filter_with.
         #
         def self.ci_match_generic( model_field_name = nil )
           Proc.new { | attr, value |
@@ -155,8 +163,9 @@ module Hoodoo
           }
         end
 
-        # As #ci_match_generic, but adds wildcards at the front and end of
-        # the string for a case-insensitive-all-wildcard match.
+        # As Hoodoo::ActiveRecord::Finder::SearchHelper::ci_match_generic,
+        # but adds wildcards at the front and end of the string for a
+        # case-insensitive-all-wildcard match.
         #
         # Results in a <tt>foo LIKE %bar% AND foo IS NOT NULL</tt> query.
         #
@@ -171,7 +180,9 @@ module Hoodoo
 
         # Case-insensitive match which requires PostgreSQL but should run
         # quickly. If you need a database agnostic solution, consider using
-        # the slower #ci_match_generic method instead.
+        # the slower
+        # Hoodoo::ActiveRecord::Finder::SearchHelper::ci_match_generic method
+        # instead.
         #
         # Results in a <tt>foo ILIKE bar AND foo IS NOT NULL</tt> query.
         #
@@ -180,8 +191,9 @@ module Hoodoo
         #                      the model attribute name here, else omit.
         #
         # Returns a value that can be asssigned to a URI query string key in
-        # the Hash given to Hoodoo::ActiveRecord::Finder#search_with or
-        # Hoodoo::ActiveRecord::Finder#filter_with.
+        # the Hash given to
+        # Hoodoo::ActiveRecord::Finder::ClassMethods#search_with or
+        # Hoodoo::ActiveRecord::Finder::ClassMethods#filter_with.
         #
         def self.ci_match_postgres( model_field_name = nil )
           Proc.new { | attr, value |
@@ -191,8 +203,9 @@ module Hoodoo
           }
         end
 
-        # As #ci_match_postgres, but adds wildcards at the front and end of
-        # the string for a case-insensitive-all-wildcard match.
+        # As Hoodoo::ActiveRecord::Finder::SearchHelper::ci_match_postgres,
+        # but adds wildcards at the front and end of the string for a
+        # case-insensitive-all-wildcard match.
         #
         # Results in a <tt>foo ILIKE %bar% AND foo IS NOT NULL</tt> query.
         #
@@ -220,8 +233,9 @@ module Hoodoo
         #                      the model attribute name here, else omit.
         #
         # Returns a value that can be asssigned to a URI query string key in
-        # the Hash given to Hoodoo::ActiveRecord::Finder#search_with or
-        # Hoodoo::ActiveRecord::Finder#filter_with.
+        # the Hash given to
+        # Hoodoo::ActiveRecord::Finder::ClassMethods#search_with or
+        # Hoodoo::ActiveRecord::Finder::ClassMethods#filter_with.
         #
         def self.cs_lt( model_field_name = nil )
           Proc.new { | attr, value |
@@ -231,7 +245,8 @@ module Hoodoo
           }
         end
 
-        # As #cs_lt, but compares with less-than-or-equal-to.
+        # As Hoodoo::ActiveRecord::Finder::SearchHelper::cs_lt, but
+        # compares with less-than-or-equal-to.
         #
         # Results in a <tt>foo <= bar AND foo IS NOT NULL</tt> query.
         #
@@ -243,7 +258,8 @@ module Hoodoo
           }
         end
 
-        # As #cs_lt, but compares with greater-than.
+        # As Hoodoo::ActiveRecord::Finder::SearchHelper::cs_lt, but
+        # compares with greater-than.
         #
         # Results in a <tt>foo > bar AND foo IS NOT NULL</tt> query.
         #
@@ -255,7 +271,8 @@ module Hoodoo
           }
         end
 
-        # As #cs_lt, but compares with greater-than-or-equal-to.
+        # As Hoodoo::ActiveRecord::Finder::SearchHelper::cs_lt, but
+        # compares with greater-than-or-equal-to.
         #
         # Results in a <tt>foo >= bar AND foo IS NOT NULL</tt> query.
         #

--- a/lib/hoodoo/active/active_record/support.rb
+++ b/lib/hoodoo/active/active_record/support.rb
@@ -69,8 +69,8 @@ module Hoodoo
         # design _before_ the model declarations are processed.
         #
         mapping = {
-          'created_after'        => Hoodoo::ActiveRecord::Finder::SearchHelper.cs_gt( :created_at ),
-          'created_on_or_before' => Hoodoo::ActiveRecord::Finder::SearchHelper.cs_lte( :created_at )
+          'created_after'  => Hoodoo::ActiveRecord::Finder::SearchHelper.cs_gt( :created_at ),
+          'created_before' => Hoodoo::ActiveRecord::Finder::SearchHelper.cs_lt( :created_at )
         }
 
         if mapping.keys.length != ( mapping.keys | Hoodoo::Services::Middleware::FRAMEWORK_QUERY_DATA.keys ).length

--- a/lib/hoodoo/active/active_record/support.rb
+++ b/lib/hoodoo/active/active_record/support.rb
@@ -35,6 +35,51 @@ module Hoodoo
     #
     class Support
 
+      # Returns a (newly generated) Hash of search keys mapping to helper Procs
+      # which are in the same format as would be passed to
+      # Hoodoo::ActiveRecord::Finder#search_with or
+      # Hoodoo::ActiveRecord::Finder#filter_with, describing the default
+      # framework search parameters. The middleware defines keys, but it is up
+      # to each ORM adapter module to specify how those keys actually get used
+      # to search inside supported database engines.
+      #
+      def self.framework_search_and_filter_data
+
+        # The middleware includes framework-level mappings between URI query
+        # string search keys and data validators and processors which convert
+        # types where necessary. For example, 'created_at' must be given a
+        # valid ISO 8601 subset string and a parsed DateTime will end up in
+        # the parsed search hash.
+        #
+        # Services opt out of framework-level searching at an interface level
+        # which means the Finder code herein, under normal flow, will never
+        # be asked to process something the interface omits. There is thus no
+        # need to try and break encapsulation and come up with a way to read
+        # the service interface's omissions. Instead, map everything.
+        #
+        # This could actually be useful if someone manually drives the #list
+        # mechanism with hand-constructed search or filter data that quite
+        # intentionally includes framework level parameters even if their own
+        # service interface for some reason opts out of allowing them to be
+        # exposed to API callers.
+        #
+        # Note that the #search_with / #filter_with DSL declaration in an
+        # appropriately extended model can be used to override the default
+        # values wired in below, because the defaults are established by
+        # design _before_ the model declarations are processed.
+        #
+        mapping = {
+          'created_after'        => Hoodoo::ActiveRecord::Finder::SearchHelper.cs_gt( :created_at ),
+          'created_on_or_before' => Hoodoo::ActiveRecord::Finder::SearchHelper.cs_lte( :created_at )
+        }
+
+        if mapping.keys.length != ( mapping.keys | Hoodoo::Services::Middleware::FRAMEWORK_QUERY_DATA.keys ).length
+          raise 'Hoodoo::ActiveRecord::Support#framework_search_and_filter_data: Mismatch between internal mapping and Hoodoo::Services::Middleware::FRAMEWORK_QUERY_DATA'
+        end
+
+        return mapping
+      end
+
       # Takes a Hash of possibly-non-String keys and with +nil+ values or
       # Proc instances appropriate for Hoodoo::ActiveRecord::Finder#search_with
       # / #filter_with. Returns a similar Hash with all-String keys and a Proc

--- a/lib/hoodoo/active/active_record/support.rb
+++ b/lib/hoodoo/active/active_record/support.rb
@@ -37,10 +37,10 @@ module Hoodoo
 
       # Returns a (newly generated) Hash of search keys mapping to helper Procs
       # which are in the same format as would be passed to
-      # Hoodoo::ActiveRecord::Finder#search_with or
-      # Hoodoo::ActiveRecord::Finder#filter_with, describing the default
-      # framework search parameters. The middleware defines keys, but it is up
-      # to each ORM adapter module to specify how those keys actually get used
+      # Hoodoo::ActiveRecord::Finder::ClassMethods#search_with or
+      # Hoodoo::ActiveRecord::Finder::ClassMethods#filter_with, describing the
+      # default framework search parameters. The middleware defines keys, but
+      # each ORM adapter module must specify how those keys actually get used
       # to search inside supported database engines.
       #
       def self.framework_search_and_filter_data

--- a/lib/hoodoo/client/paginated_enumeration.rb
+++ b/lib/hoodoo/client/paginated_enumeration.rb
@@ -52,7 +52,7 @@ module Hoodoo
           if results.size > 0
 
             if results.platform_errors.has_errors?
-              raise "Hoodoo::Client:: PaginatedEnumeration#enumerate_all: Unexpected internal state combination of results set and results error indication"
+              raise 'Hoodoo::Client::PaginatedEnumeration#enumerate_all: Unexpected internal state combination of results set and results error indication'
             end
 
             # Yield a resource at a time to the caller

--- a/lib/hoodoo/services/middleware/middleware.rb
+++ b/lib/hoodoo/services/middleware/middleware.rb
@@ -206,6 +206,10 @@ module Hoodoo; module Services
     # String type into a more useful comparable entity such as an Integer or
     # DateTime.
     #
+    # *IMPORTANT* - if this list is changed, any database support modules -
+    # e.g. in Hoodoo::ActiveRecord::Support - will need any internal mapping
+    # of "framework query keys to module-appropriate query code" updating.
+    #
     FRAMEWORK_QUERY_DATA = {
       'created_after'        => FRAMEWORK_QUERY_VALUE_DATE_PROC,
       'created_on_or_before' => FRAMEWORK_QUERY_VALUE_DATE_PROC,

--- a/lib/hoodoo/services/middleware/middleware.rb
+++ b/lib/hoodoo/services/middleware/middleware.rb
@@ -177,7 +177,7 @@ module Hoodoo; module Services
 
     # A validation Proc for FRAMEWORK_QUERY_DATA - see that for details. This
     # one ensures that the value is a valid ISO 8601 subset date/time string
-    # and evalutes to the parsed version of that string if so.
+    # and evaluates to the parsed version of that string if so.
     #
     FRAMEWORK_QUERY_VALUE_DATE_PROC = -> ( value ) {
       Hoodoo::Utilities.valid_iso8601_subset_datetime?( value ) ?
@@ -193,10 +193,12 @@ module Hoodoo; module Services
     # Keys, in order, are:
     #
     # * Query key to detect records with a +created_at+ date that is after the
-    #   given value, in supporting resource
+    #   given value, in supporting resource; if used as a filter instead of a
+    #   search string, would find records on-or-before the date.
     #
-    # * Query key to detect records with a +created_at+ date that is on or
-    #   before the given value, in supporting resource
+    # * Query key to detect records with a +created_at+ date that is before
+    #   the given value, in supporting resource; if used as a filter instead
+    #   of a search string, would find records on-or-after the date.
     #
     # Values are either a validation Proc or +nil+ for no validation. The
     # Proc takes the search query value as its sole input paraeter and must
@@ -211,8 +213,8 @@ module Hoodoo; module Services
     # of "framework query keys to module-appropriate query code" updating.
     #
     FRAMEWORK_QUERY_DATA = {
-      'created_after'        => FRAMEWORK_QUERY_VALUE_DATE_PROC,
-      'created_on_or_before' => FRAMEWORK_QUERY_VALUE_DATE_PROC,
+      'created_after'  => FRAMEWORK_QUERY_VALUE_DATE_PROC,
+      'created_before' => FRAMEWORK_QUERY_VALUE_DATE_PROC,
     }
 
     # Utility - returns the execution environment as a Rails-like environment

--- a/lib/hoodoo/services/services/interface.rb
+++ b/lib/hoodoo/services/services/interface.rb
@@ -58,9 +58,19 @@ module Hoodoo; module Services
       #
       attr_reader :search
 
+      # Array of prohibited framework search keys as Strings; empty for none
+      # defined.
+      #
+      attr_reader :do_not_search
+
       # Array of supported filter keys as Strings; empty for none defined.
       #
       attr_reader :filter
+
+      # Array of prohibited framewor filter keys as Strings; empty for none
+      # defined.
+      #
+      attr_reader :do_not_filter
 
       # Create an instance with default settings.
       #
@@ -74,7 +84,9 @@ module Hoodoo; module Services
         @sort             = { 'created_at' => Set.new( [ 'desc', 'asc' ] ) }
         @default_sort_key = 'created_at'
         @search           = []
+        @do_not_search    = []
         @filter           = []
+        @do_not_filter    = []
       end
 
       private
@@ -103,11 +115,23 @@ module Hoodoo; module Services
         #
         attr_writer :search
 
+        # Private writer - see #do_not_search - but there's a special contract
+        # with Hoodoo::Services::Interface::ToListDSL which permits it to call
+        # here bypassing +private+ via +send()+.
+        #
+        attr_writer :do_not_search
+
         # Private writer - see #filter - but there's a special contract with
         # Hoodoo::Services::Interface::ToListDSL which permits it to call here
         # bypassing +private+ via +send()+.
         #
         attr_writer :filter
+
+        # Private writer - see #do_not_filter - but there's a special contract
+        # with Hoodoo::Services::Interface::ToListDSL which permits it to call
+        # here bypassing +private+ via +send()+.
+        #
+        attr_writer :do_not_filter
 
     end # 'class ToList'
 
@@ -223,25 +247,44 @@ module Hoodoo; module Services
       # value escaping and validation, if necessary, is up to the service
       # implementation.
       #
-      # +search+:: Array of permitted search keys, as symbols or strings.
-      #            The order of array entries is arbitrary.
+      # +keys+:: Array of permitted search keys, as symbols or strings.
+      #          The order of array entries is arbitrary.
       #
       # Example - allow searches specifying +first_name+ and +last_name+ keys:
       #
       #     search :first_name, :last_name
       #
-      def search( *search )
-        @tl.send( :search=, search.map { | item | item.to_s } )
+      def search( *keys )
+        @tl.send( :search=, keys.map { | item | item.to_s } )
+      end
+
+      # Similar to #search, but for default Hoodoo framework exclusions.
+      #
+      # +keys+:: Array of prohibited framework search keys, as symbols or
+      #          strings. The order of array entries is arbitrary.
+      #
+      def do_not_search( *keys )
+        @tl.send( :do_not_search=, keys.map { | item | item.to_s } )
       end
 
       # As #search, but for filtering.
       #
-      # +filter+:: Array of permitted filter keys, as symbols or strings.
-      #            The order of array entries is arbitrary.
+      # +keys+:: Array of permitted filter keys, as symbols or strings.
+      #          The order of array entries is arbitrary.
       #
-      def filter( *filter )
-        @tl.send( :filter=, filter.map { | item | item.to_s } )
+      def filter( *keys )
+        @tl.send( :filter=, keys.map { | item | item.to_s } )
       end
+
+      # As #do_not_search, but for default Hoodoo framework exclusions.
+      #
+      # +keys+:: Array of prohibited framework filter keys, as symbols or
+      #          strings. The order of array entries is arbitrary.
+      #
+      def do_not_filter( *keys )
+        @tl.send( :do_not_filter=, keys.map { | item | item.to_s } )
+      end
+
     end # 'class ToListDSL'
 
     ###########################################################################

--- a/lib/hoodoo/services/services/interface.rb
+++ b/lib/hoodoo/services/services/interface.rb
@@ -258,13 +258,22 @@ module Hoodoo; module Services
         @tl.send( :search=, keys.map { | item | item.to_s } )
       end
 
-      # Similar to #search, but for default Hoodoo framework exclusions.
+      # Similar to #search, but for default Hoodoo framework exclusions. The
+      # Hoodoo::Services::Middleware::FRAMEWORK_QUERY_KEYS array lists the
+      # known framework keys for a given Hoodoo version. An exception is
+      # raised if an attempt is made to exclude unknown keys.
       #
       # +keys+:: Array of prohibited framework search keys, as symbols or
       #          strings. The order of array entries is arbitrary.
       #
       def do_not_search( *keys )
         @tl.send( :do_not_search=, keys.map { | item | item.to_s } )
+
+        unknown = @tl.do_not_search() - Hoodoo::Services::Middleware::FRAMEWORK_QUERY_KEYS
+
+        unless unknown.empty?
+          raise "Hoodoo::Services::Interface::ToListDSL\#do_not_search was given one or more unknown keys: #{ unknown.join( ', ' ) }"
+        end
       end
 
       # As #search, but for filtering.
@@ -283,6 +292,12 @@ module Hoodoo; module Services
       #
       def do_not_filter( *keys )
         @tl.send( :do_not_filter=, keys.map { | item | item.to_s } )
+
+        unknown = @tl.do_not_filter() - Hoodoo::Services::Middleware::FRAMEWORK_QUERY_KEYS
+
+        unless unknown.empty?
+          raise "Hoodoo::Services::Interface::ToListDSL\#do_not_filter was given one or more unknown keys: #{ unknown.join( ', ' ) }"
+        end
       end
 
     end # 'class ToListDSL'

--- a/lib/hoodoo/services/services/interface.rb
+++ b/lib/hoodoo/services/services/interface.rb
@@ -259,7 +259,7 @@ module Hoodoo; module Services
       end
 
       # Similar to #search, but for default Hoodoo framework exclusions. The
-      # Hoodoo::Services::Middleware::FRAMEWORK_QUERY_DATA array lists the
+      # Hoodoo::Services::Middleware +FRAMEWORK_QUERY_DATA+ array lists the
       # known framework keys for a given Hoodoo version. An exception is
       # raised if an attempt is made to exclude unknown keys.
       #

--- a/lib/hoodoo/services/services/interface.rb
+++ b/lib/hoodoo/services/services/interface.rb
@@ -259,7 +259,7 @@ module Hoodoo; module Services
       end
 
       # Similar to #search, but for default Hoodoo framework exclusions. The
-      # Hoodoo::Services::Middleware::FRAMEWORK_QUERY_KEYS array lists the
+      # Hoodoo::Services::Middleware::FRAMEWORK_QUERY_DATA array lists the
       # known framework keys for a given Hoodoo version. An exception is
       # raised if an attempt is made to exclude unknown keys.
       #
@@ -269,7 +269,7 @@ module Hoodoo; module Services
       def do_not_search( *keys )
         @tl.send( :do_not_search=, keys.map { | item | item.to_s } )
 
-        unknown = @tl.do_not_search() - Hoodoo::Services::Middleware::FRAMEWORK_QUERY_KEYS
+        unknown = @tl.do_not_search() - Hoodoo::Services::Middleware::FRAMEWORK_QUERY_DATA.keys
 
         unless unknown.empty?
           raise "Hoodoo::Services::Interface::ToListDSL\#do_not_search was given one or more unknown keys: #{ unknown.join( ', ' ) }"
@@ -293,7 +293,7 @@ module Hoodoo; module Services
       def do_not_filter( *keys )
         @tl.send( :do_not_filter=, keys.map { | item | item.to_s } )
 
-        unknown = @tl.do_not_filter() - Hoodoo::Services::Middleware::FRAMEWORK_QUERY_KEYS
+        unknown = @tl.do_not_filter() - Hoodoo::Services::Middleware::FRAMEWORK_QUERY_DATA.keys
 
         unless unknown.empty?
           raise "Hoodoo::Services::Interface::ToListDSL\#do_not_filter was given one or more unknown keys: #{ unknown.join( ', ' ) }"

--- a/spec/active/active_record/finder_spec.rb
+++ b/spec/active/active_record/finder_spec.rb
@@ -623,7 +623,14 @@ describe Hoodoo::ActiveRecord::Finder do
       expect( finder ).to eq([@c])
 
       @list_params.search_data = {
-        'created_on_or_before' => @tn - 1.month
+        'created_before' => @tn - 1.month
+      }
+
+      finder = RSpecModelFinderTest.list( @list_params )
+      expect( finder ).to eq([@a])
+
+      @list_params.search_data = {
+        'created_before' => @tn - 1.month + 1.day
       }
 
       finder = RSpecModelFinderTest.list( @list_params )
@@ -677,7 +684,14 @@ describe Hoodoo::ActiveRecord::Finder do
       expect( finder ).to eq([])
 
       @list_params.search_data = {
-        'created_on_or_before' => @tn - 1.month
+        'created_before' => @tn - 1.month
+      }
+
+      finder = constraint.list( @list_params )
+      expect( finder ).to eq([@a])
+
+      @list_params.search_data = {
+        'created_before' => @tn - 1.month + 1.day
       }
 
       finder = constraint.list( @list_params )
@@ -805,7 +819,14 @@ describe Hoodoo::ActiveRecord::Finder do
       expect( finder ).to eq([@b, @a])
 
       @list_params.filter_data = {
-        'created_on_or_before' => @tn - 1.month
+        'created_before' => @tn - 1.month
+      }
+
+      finder = RSpecModelFinderTest.list( @list_params )
+      expect( finder ).to eq([@c, @b])
+
+      @list_params.filter_data = {
+        'created_before' => @tn - 1.month + 1.day
       }
 
       finder = RSpecModelFinderTest.list( @list_params )
@@ -863,7 +884,14 @@ describe Hoodoo::ActiveRecord::Finder do
       expect( finder ).to eq([])
 
       @list_params.filter_data = {
-        'created_on_or_before' => @tn - 1.month
+        'created_before' => @tn - 1.month
+      }
+
+      finder = constraint.list( @list_params )
+      expect( finder ).to eq([@c])
+
+      @list_params.filter_data = {
+        'created_before' => @tn - 1.month + 1.day
       }
 
       finder = constraint.list( @list_params )

--- a/spec/active/active_record/finder_spec.rb
+++ b/spec/active/active_record/finder_spec.rb
@@ -92,12 +92,15 @@ describe Hoodoo::ActiveRecord::Finder do
   end
 
   before :each do
+    @tn = Time.now.round()
+
     @a = RSpecModelFinderTest.new
     @a.id = "one"
     @a.code = 'A' # Must be set else SQLite fails to find this if you search for "code != 'C'" (!)
     @a.field_one = 'group 1'
     @a.field_two = 'two a'
     @a.field_three = 'three a'
+    @a.created_at = @tn - 1.year
     @a.save!
     @id = @a.id
 
@@ -108,6 +111,7 @@ describe Hoodoo::ActiveRecord::Finder do
     @b.field_one = 'group 1'
     @b.field_two = 'two b'
     @b.field_three = 'three b'
+    @b.created_at = @tn - 1.month
     @b.save!
     @uuid = @b.uuid
 
@@ -117,6 +121,7 @@ describe Hoodoo::ActiveRecord::Finder do
     @c.field_one = 'group 2'
     @c.field_two = 'two c'
     @c.field_three = 'three c'
+    @c.created_at = @tn
     @c.save!
     @code = @c.code
 
@@ -610,6 +615,20 @@ describe Hoodoo::ActiveRecord::Finder do
 
       finder = RSpecModelFinderTest.list( @list_params )
       expect( finder ).to eq([@c])
+
+      @list_params.search_data = {
+        'created_after' => @tn - 1.month
+      }
+
+      finder = RSpecModelFinderTest.list( @list_params )
+      expect( finder ).to eq([@c])
+
+      @list_params.search_data = {
+        'created_on_or_before' => @tn - 1.month
+      }
+
+      finder = RSpecModelFinderTest.list( @list_params )
+      expect( finder ).to eq([@b, @a])
     end
 
     it 'searches with chain' do
@@ -650,6 +669,20 @@ describe Hoodoo::ActiveRecord::Finder do
 
       finder = constraint.list( @list_params )
       expect( finder ).to eq([])
+
+      @list_params.search_data = {
+        'created_after' => @tn - 1.month
+      }
+
+      finder = constraint.list( @list_params )
+      expect( finder ).to eq([])
+
+      @list_params.search_data = {
+        'created_on_or_before' => @tn - 1.month
+      }
+
+      finder = constraint.list( @list_params )
+      expect( finder ).to eq([@b, @a])
     end
   end
 
@@ -748,6 +781,20 @@ describe Hoodoo::ActiveRecord::Finder do
 
       finder = RSpecModelFinderTest.list( @list_params )
       expect( finder ).to eq([@b])
+
+      @list_params.filter_data = {
+        'created_after' => @tn - 1.month
+      }
+
+      finder = RSpecModelFinderTest.list( @list_params )
+      expect( finder ).to eq([@b, @a])
+
+      @list_params.filter_data = {
+        'created_on_or_before' => @tn - 1.month
+      }
+
+      finder = RSpecModelFinderTest.list( @list_params )
+      expect( finder ).to eq([@c])
     end
 
     it 'filters with chain' do
@@ -792,6 +839,20 @@ describe Hoodoo::ActiveRecord::Finder do
 
       finder = constraint.list( @list_params )
       expect( finder ).to eq([])
+
+      @list_params.filter_data = {
+        'created_after' => @tn - 1.month
+      }
+
+      finder = constraint.list( @list_params )
+      expect( finder ).to eq([])
+
+      @list_params.filter_data = {
+        'created_on_or_before' => @tn - 1.month
+      }
+
+      finder = constraint.list( @list_params )
+      expect( finder ).to eq([@c])
     end
   end
 
@@ -866,6 +927,7 @@ describe Hoodoo::ActiveRecord::Finder do
       @scoped_1.uuid = 'uuid 1'
       @scoped_1.code = 'code 1'
       @scoped_1.field_one = 'scoped 1'
+      @scoped_1.created_at = @tn - 1.year
       @scoped_1.save!
 
       @scoped_2 = RSpecModelFinderTest.new

--- a/spec/active/active_record/search_helper_spec.rb
+++ b/spec/active/active_record/search_helper_spec.rb
@@ -27,17 +27,6 @@ describe Hoodoo::ActiveRecord::Finder::SearchHelper do
     end
   end
 
-  before :each do
-    @f1 = RSpecModelSearchHelperTest.create
-    @f2 = RSpecModelSearchHelperTest.create( :field => 'hello' )
-    @f3 = RSpecModelSearchHelperTest.create( :field => 'hello' )
-    @f4 = RSpecModelSearchHelperTest.create( :field => 'HELLO' )
-    @f5 = RSpecModelSearchHelperTest.create
-    @f6 = RSpecModelSearchHelperTest.create( :field => 'world' )
-    @f7 = RSpecModelSearchHelperTest.create( :field => 'world' )
-    @f8 = RSpecModelSearchHelperTest.create( :field => 'WORLD' )
-  end
-
   def find( clause )
     RSpecModelSearchHelperTest.where( *clause ).all
   end
@@ -47,386 +36,624 @@ describe Hoodoo::ActiveRecord::Finder::SearchHelper do
   end
 
   #############################################################################
+  # Although the queries in this section can match things other than strings
+  # in some cases, they're aimed at string comparison most of the time.
+  #############################################################################
 
-  context '#cs_match' do
-    it 'generates expected no-input-parameter output' do
-      result = described_class.cs_match
-      expect( result.call( 'a', 'b' ) ).to eq( [ 'a = ? AND a IS NOT NULL', 'b' ] )
+  context 'equality' do
+    before :each do
+      @f1 = RSpecModelSearchHelperTest.create
+      @f2 = RSpecModelSearchHelperTest.create( :field => 'hello' )
+      @f3 = RSpecModelSearchHelperTest.create( :field => 'hello' )
+      @f4 = RSpecModelSearchHelperTest.create( :field => 'HELLO' )
+      @f5 = RSpecModelSearchHelperTest.create
+      @f6 = RSpecModelSearchHelperTest.create( :field => 'world' )
+      @f7 = RSpecModelSearchHelperTest.create( :field => 'world' )
+      @f8 = RSpecModelSearchHelperTest.create( :field => 'WORLD' )
     end
 
-    it 'generates expected one-input-parameter output' do
-      result = described_class.cs_match( :bar )
-      expect( result.call( 'a', 'b' ) ).to eq( [ 'bar = ? AND bar IS NOT NULL', 'b' ] )
+    ###########################################################################
+
+    context '#cs_match' do
+      it 'generates expected no-input-parameter output' do
+        result = described_class.cs_match
+        expect( result.call( 'a', 'b' ) ).to eq( [ 'a = ? AND a IS NOT NULL', 'b' ] )
+      end
+
+      it 'generates expected one-input-parameter output' do
+        result = described_class.cs_match( :bar )
+        expect( result.call( 'a', 'b' ) ).to eq( [ 'bar = ? AND bar IS NOT NULL', 'b' ] )
+      end
+
+      it 'finds expected things' do
+        result = find( described_class.cs_match.call( 'field', 'hello' ) )
+        expect( result ).to match_array( [ @f2, @f3 ] )
+
+        result = find( described_class.cs_match.call( 'field', 'HELLO' ) )
+        expect( result ).to match_array( [ @f4 ] )
+
+        result = find( described_class.cs_match.call( 'field', 'hell' ) )
+        expect( result ).to match_array( [] )
+
+        result = find( described_class.cs_match.call( 'field', 'llo' ) )
+        expect( result ).to match_array( [] )
+
+        result = find( described_class.cs_match.call( 'field', 'heLLo' ) )
+        expect( result ).to match_array( [] )
+      end
+
+      it 'finds expected things negated' do
+        result = find_not( described_class.cs_match.call( 'field', 'hello' ) )
+        expect( result ).to match_array( [ @f1,           @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.cs_match.call( 'field', 'HELLO' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3,      @f5, @f6, @f7, @f8  ] )
+
+        result = find_not( described_class.cs_match.call( 'field', 'hell' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.cs_match.call( 'field', 'llo' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.cs_match.call( 'field', 'heLLo' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+      end
     end
 
-    it 'finds expected things' do
-      result = find( described_class.cs_match.call( 'field', 'hello' ) )
-      expect( result ).to match_array( [ @f2, @f3 ] )
+    ###########################################################################
 
-      result = find( described_class.cs_match.call( 'field', 'HELLO' ) )
-      expect( result ).to match_array( [ @f4 ] )
+    context '#cs_match_csv' do
+      it 'generates expected no-input-parameter output' do
+        result = described_class.cs_match_csv()
+        expect( result.call( 'a', 'b,c,d' ) ).to eq( [ 'a IN (?) AND a IS NOT NULL', [ 'b', 'c', 'd' ] ] )
+      end
 
-      result = find( described_class.cs_match.call( 'field', 'hell' ) )
-      expect( result ).to match_array( [] )
+      it 'generates expected one-input-parameter output' do
+        result = described_class.cs_match_csv( :bar )
+        expect( result.call( 'a', 'b,c,d' ) ).to eq( [ 'bar IN (?) AND bar IS NOT NULL', [ 'b', 'c', 'd' ] ] )
+      end
 
-      result = find( described_class.cs_match.call( 'field', 'llo' ) )
-      expect( result ).to match_array( [] )
+      it 'finds expected things' do
+        result = find( described_class.cs_match_csv.call( 'field', 'hello,world' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f6, @f7 ] )
 
-      result = find( described_class.cs_match.call( 'field', 'heLLo' ) )
-      expect( result ).to match_array( [] )
+        result = find( described_class.cs_match_csv.call( 'field', 'HELLO,WORLD' ) )
+        expect( result ).to match_array( [ @f4, @f8 ] )
+
+        result = find( described_class.cs_match_csv.call( 'field', 'hell,worl' ) )
+        expect( result ).to match_array( [] )
+
+        result = find( described_class.cs_match_csv.call( 'field', 'llo,ld' ) )
+        expect( result ).to match_array( [] )
+
+        result = find( described_class.cs_match_csv.call( 'field', 'heLLo,WORld' ) )
+        expect( result ).to match_array( [] )
+      end
+
+      it 'finds expected things negated' do
+        result = find_not( described_class.cs_match_csv.call( 'field', 'hello,world' ) )
+        expect( result ).to match_array( [ @f1,           @f4, @f5,          @f8 ] )
+
+        result = find_not( described_class.cs_match_csv.call( 'field', 'HELLO,WORLD' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3,      @f5, @f6, @f7      ] )
+
+        result = find_not( described_class.cs_match_csv.call( 'field', 'hell,worl' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.cs_match_csv.call( 'field', 'llo,ld' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.cs_match_csv.call( 'field', 'heLLo,WORld' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+      end
     end
 
-    it 'finds expected things negated' do
-      result = find_not( described_class.cs_match.call( 'field', 'hello' ) )
-      expect( result ).to match_array( [ @f1,           @f4, @f5, @f6, @f7, @f8 ] )
+    ###########################################################################
 
-      result = find_not( described_class.cs_match.call( 'field', 'HELLO' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3,      @f5, @f6, @f7, @f8  ] )
+    context '#cs_match_array' do
+      it 'generates expected no-input-parameter output' do
+        result = described_class.cs_match_array()
+        expect( result.call( 'a', [ 'b', 'c', 'd' ] ) ).to eq( [ 'a IN (?) AND a IS NOT NULL', [ 'b', 'c', 'd' ] ] )
+      end
 
-      result = find_not( described_class.cs_match.call( 'field', 'hell' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+      it 'generates expected one-input-parameter output' do
+        result = described_class.cs_match_array( :bar )
+        expect( result.call( 'a', [ 'b', 'c', 'd' ] ) ).to eq( [ 'bar IN (?) AND bar IS NOT NULL', [ 'b', 'c', 'd' ] ] )
+      end
 
-      result = find_not( described_class.cs_match.call( 'field', 'llo' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+      it 'finds expected things' do
+        result = find( described_class.cs_match_array.call( 'field', [ 'hello', 'world' ] ) )
+        expect( result ).to match_array( [ @f2, @f3, @f6, @f7 ] )
 
-      result = find_not( described_class.cs_match.call( 'field', 'heLLo' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+        result = find( described_class.cs_match_array.call( 'field', [ 'HELLO', 'WORLD' ] ) )
+        expect( result ).to match_array( [ @f4, @f8 ] )
+
+        result = find( described_class.cs_match_array.call( 'field', [ 'hell', 'worl' ] ) )
+        expect( result ).to match_array( [] )
+
+        result = find( described_class.cs_match_array.call( 'field', [ 'llo', 'ld' ] ) )
+        expect( result ).to match_array( [] )
+
+        result = find( described_class.cs_match_array.call( 'field', [ 'heLLo', 'WORld' ] ) )
+        expect( result ).to match_array( [] )
+      end
+
+      it 'finds expected things negated' do
+        result = find_not( described_class.cs_match_array.call( 'field', [ 'hello', 'world' ] ) )
+        expect( result ).to match_array( [ @f1,           @f4, @f5,          @f8 ] )
+
+        result = find_not( described_class.cs_match_array.call( 'field', [ 'HELLO', 'WORLD' ] ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3,      @f5, @f6, @f7      ] )
+
+        result = find_not( described_class.cs_match_array.call( 'field', [ 'hell', 'worl' ] ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.cs_match_array.call( 'field', [ 'llo', 'ld' ] ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.cs_match_array.call( 'field', [ 'heLLo', 'WORld' ] ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+      end
     end
+
+    ###########################################################################
+
+    context '#ci_match_generic' do
+      it 'generates expected no-input-parameter output' do
+        result = described_class.ci_match_generic()
+        expect( result.call( 'a', 'B' ) ).to eq( [ 'lower(a) = ? AND a IS NOT NULL', 'b' ] )
+      end
+
+      it 'generates expected one-input-parameter output' do
+        result = described_class.ci_match_generic( :bar )
+        expect( result.call( 'a', 'B' ) ).to eq( [ 'lower(bar) = ? AND bar IS NOT NULL', 'b' ] )
+      end
+
+      it 'finds expected things' do
+        result = find( described_class.ci_match_generic.call( 'field', 'hello' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+
+        result = find( described_class.ci_match_generic.call( 'field', 'HELLO' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+
+        result = find( described_class.ci_match_generic.call( 'field', 'hell' ) )
+        expect( result ).to match_array( [] )
+
+        result = find( described_class.ci_match_generic.call( 'field', 'llo' ) )
+        expect( result ).to match_array( [] )
+
+        result = find( described_class.ci_match_generic.call( 'field', 'heLLo' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+      end
+
+      it 'finds expected things negated' do
+        result = find_not( described_class.ci_match_generic.call( 'field', 'hello' ) )
+        expect( result ).to match_array( [ @f1,                @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ci_match_generic.call( 'field', 'HELLO' ) )
+        expect( result ).to match_array( [ @f1,                @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ci_match_generic.call( 'field', 'hell' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ci_match_generic.call( 'field', 'llo' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ci_match_generic.call( 'field', 'heLLo' ) )
+        expect( result ).to match_array( [ @f1,                @f5, @f6, @f7, @f8 ] )
+      end
+    end
+
+    ###########################################################################
+
+    context '#ciaw_match_generic' do
+      it 'generates expected no-input-parameter output' do
+        result = described_class.ciaw_match_generic()
+        expect( result.call( 'a', 'B' ) ).to eq( [ 'lower(a) LIKE ? AND a IS NOT NULL', '%b%' ] )
+      end
+
+      it 'generates expected one-input-parameter output' do
+        result = described_class.ciaw_match_generic( :bar )
+        expect( result.call( 'a', 'B' ) ).to eq( [ 'lower(bar) LIKE ? AND bar IS NOT NULL', '%b%' ] )
+      end
+
+      it 'finds expected things' do
+        result = find( described_class.ciaw_match_generic.call( 'field', 'hello' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+
+        result = find( described_class.ciaw_match_generic.call( 'field', 'HELLO' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+
+        result = find( described_class.ciaw_match_generic.call( 'field', 'hell' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+
+        result = find( described_class.ciaw_match_generic.call( 'field', 'llo' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+
+        result = find( described_class.ciaw_match_generic.call( 'field', 'heLLo' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+      end
+
+      it 'finds expected things negated' do
+        result = find_not( described_class.ciaw_match_generic.call( 'field', 'hello' ) )
+        expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ciaw_match_generic.call( 'field', 'HELLO' ) )
+        expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ciaw_match_generic.call( 'field', 'hell' ) )
+        expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ciaw_match_generic.call( 'field', 'llo' ) )
+        expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ciaw_match_generic.call( 'field', 'heLLo' ) )
+        expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
+      end
+    end
+
+    ###########################################################################
+
+    context '#csaw_match' do
+      it 'generates expected no-input-parameter output' do
+        result = described_class.csaw_match()
+        expect( result.call( 'a', 'B' ) ).to eq( [ 'a LIKE ? AND a IS NOT NULL', '%B%' ] )
+      end
+
+      it 'generates expected one-input-parameter output' do
+        result = described_class.csaw_match( :bar )
+        expect( result.call( 'a', 'B' ) ).to eq( [ 'bar LIKE ? AND bar IS NOT NULL', '%B%' ] )
+      end
+
+      it 'finds expected things' do
+        result = find( described_class.csaw_match.call( 'field', 'hello' ) )
+        expect( result ).to match_array( [ @f2, @f3 ] )
+
+        result = find( described_class.csaw_match.call( 'field', 'HELLO' ) )
+        expect( result ).to match_array( [ @f4 ] )
+
+        result = find( described_class.csaw_match.call( 'field', 'hell' ) )
+        expect( result ).to match_array( [ @f2, @f3 ] )
+
+        result = find( described_class.csaw_match.call( 'field', 'llo' ) )
+        expect( result ).to match_array( [ @f2, @f3 ] )
+
+        result = find( described_class.csaw_match.call( 'field', 'heLLo' ) )
+        expect( result ).to match_array( [  ] )
+      end
+
+      it 'finds expected things negated' do
+        result = find_not( described_class.csaw_match.call( 'field', 'hello' ) )
+        expect( result ).to match_array( [ @f1, @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.csaw_match.call( 'field', 'HELLO' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.csaw_match.call( 'field', 'hell' ) )
+        expect( result ).to match_array( [ @f1, @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.csaw_match.call( 'field', 'llo' ) )
+        expect( result ).to match_array( [ @f1, @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.csaw_match.call( 'field', 'heLLo' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+      end
+    end
+
+    ###########################################################################
+
+    context '#ci_match_postgres' do
+      it 'generates expected no-input-parameter output' do
+        result = described_class.ci_match_postgres()
+        expect( result.call( 'a', 'B' ) ).to eq( [ 'a ILIKE ? AND a IS NOT NULL', 'B' ] )
+      end
+
+      it 'generates expected one-input-parameter output' do
+        result = described_class.ci_match_postgres( :bar )
+        expect( result.call( 'a', 'B' ) ).to eq( [ 'bar ILIKE ? AND bar IS NOT NULL', 'B' ] )
+      end
+
+      it 'finds expected things' do
+        result = find( described_class.ci_match_postgres.call( 'field', 'hello' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+
+        result = find( described_class.ci_match_postgres.call( 'field', 'HELLO' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+
+        result = find( described_class.ci_match_postgres.call( 'field', 'hell' ) )
+        expect( result ).to match_array( [] )
+
+        result = find( described_class.ci_match_postgres.call( 'field', 'llo' ) )
+        expect( result ).to match_array( [] )
+
+        result = find( described_class.ci_match_postgres.call( 'field', 'heLLo' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+      end
+
+      it 'finds expected things negated' do
+        result = find_not( described_class.ci_match_postgres.call( 'field', 'hello' ) )
+        expect( result ).to match_array( [ @f1,                @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ci_match_postgres.call( 'field', 'HELLO' ) )
+        expect( result ).to match_array( [ @f1,                @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ci_match_postgres.call( 'field', 'hell' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ci_match_postgres.call( 'field', 'llo' ) )
+        expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ci_match_postgres.call( 'field', 'heLLo' ) )
+        expect( result ).to match_array( [ @f1,                @f5, @f6, @f7, @f8 ] )
+      end
+    end
+
+    ###########################################################################
+
+    context '#ciaw_match_postgres' do
+      it 'generates expected no-input-parameter output' do
+        result = described_class.ciaw_match_postgres()
+        expect( result.call( 'a', 'B' ) ).to eq( [ 'a ILIKE ? AND a IS NOT NULL', '%B%' ] )
+      end
+
+      it 'generates expected one-input-parameter output' do
+        result = described_class.ciaw_match_postgres( :bar )
+        expect( result.call( 'a', 'B' ) ).to eq( [ 'bar ILIKE ? AND bar IS NOT NULL', '%B%' ] )
+      end
+
+      it 'finds expected things' do
+        result = find( described_class.ciaw_match_postgres.call( 'field', 'hello' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+
+        result = find( described_class.ciaw_match_postgres.call( 'field', 'HELLO' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+
+        result = find( described_class.ciaw_match_postgres.call( 'field', 'hell' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+
+        result = find( described_class.ciaw_match_postgres.call( 'field', 'llo' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+
+        result = find( described_class.ciaw_match_postgres.call( 'field', 'heLLo' ) )
+        expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+      end
+
+      it 'finds expected things negated' do
+        result = find_not( described_class.ciaw_match_postgres.call( 'field', 'hello' ) )
+        expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ciaw_match_postgres.call( 'field', 'HELLO' ) )
+        expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ciaw_match_postgres.call( 'field', 'hell' ) )
+        expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ciaw_match_postgres.call( 'field', 'llo' ) )
+        expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
+
+        result = find_not( described_class.ciaw_match_postgres.call( 'field', 'heLLo' ) )
+        expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
+      end
+    end
+
+    ###########################################################################
+
   end
 
   #############################################################################
-
-  context '#cs_match_csv' do
-    it 'generates expected no-input-parameter output' do
-      result = described_class.cs_match_csv()
-      expect( result.call( 'a', 'b,c,d' ) ).to eq( [ 'a IN (?) AND a IS NOT NULL', [ 'b', 'c', 'd' ] ] )
-    end
-
-    it 'generates expected one-input-parameter output' do
-      result = described_class.cs_match_csv( :bar )
-      expect( result.call( 'a', 'b,c,d' ) ).to eq( [ 'bar IN (?) AND bar IS NOT NULL', [ 'b', 'c', 'd' ] ] )
-    end
-
-    it 'finds expected things' do
-      result = find( described_class.cs_match_csv.call( 'field', 'hello,world' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f6, @f7 ] )
-
-      result = find( described_class.cs_match_csv.call( 'field', 'HELLO,WORLD' ) )
-      expect( result ).to match_array( [ @f4, @f8 ] )
-
-      result = find( described_class.cs_match_csv.call( 'field', 'hell,worl' ) )
-      expect( result ).to match_array( [] )
-
-      result = find( described_class.cs_match_csv.call( 'field', 'llo,ld' ) )
-      expect( result ).to match_array( [] )
-
-      result = find( described_class.cs_match_csv.call( 'field', 'heLLo,WORld' ) )
-      expect( result ).to match_array( [] )
-    end
-
-    it 'finds expected things negated' do
-      result = find_not( described_class.cs_match_csv.call( 'field', 'hello,world' ) )
-      expect( result ).to match_array( [ @f1,           @f4, @f5,          @f8 ] )
-
-      result = find_not( described_class.cs_match_csv.call( 'field', 'HELLO,WORLD' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3,      @f5, @f6, @f7      ] )
-
-      result = find_not( described_class.cs_match_csv.call( 'field', 'hell,worl' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.cs_match_csv.call( 'field', 'llo,ld' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.cs_match_csv.call( 'field', 'heLLo,WORld' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
-    end
-  end
-
+  # Although the queries in this section can match things other than dates
+  # easily - e.g. compare integers or strings - they were created initially
+  # for date comparisons so the seed data for tests is based on dates only.
   #############################################################################
 
-  context '#cs_match_array' do
-    it 'generates expected no-input-parameter output' do
-      result = described_class.cs_match_array()
-      expect( result.call( 'a', [ 'b', 'c', 'd' ] ) ).to eq( [ 'a IN (?) AND a IS NOT NULL', [ 'b', 'c', 'd' ] ] )
+  context 'difference' do
+    before :each do
+      @tn = Time.now.round()
+      @t1 = RSpecModelSearchHelperTest.create( :created_at => @tn           )
+      @t2 = RSpecModelSearchHelperTest.create( :created_at => @tn           )
+      @t3 = RSpecModelSearchHelperTest.create( :created_at => @tn - 1.month )
+      @t4 = RSpecModelSearchHelperTest.create( :created_at => @tn - 1.month )
+      @t5 = RSpecModelSearchHelperTest.create( :created_at => @tn - 1.year  )
+      @t6 = RSpecModelSearchHelperTest.create( :created_at => @tn - 1.year  )
+      @t7 = RSpecModelSearchHelperTest.create
+
+      sql = "UPDATE r_spec_model_search_helper_tests SET created_at=NULL WHERE id=#{ @t7.id }"
+      ActiveRecord::Base.connection.execute( sql )
     end
 
-    it 'generates expected one-input-parameter output' do
-      result = described_class.cs_match_array( :bar )
-      expect( result.call( 'a', [ 'b', 'c', 'd' ] ) ).to eq( [ 'bar IN (?) AND bar IS NOT NULL', [ 'b', 'c', 'd' ] ] )
+    ###########################################################################
+
+    context '#cs_lt' do
+      it 'generates expected no-input-parameter output' do
+        result = described_class.cs_lt()
+        expect( result.call( 'a', 'b' ) ).to eq( [ 'a < ? AND a IS NOT NULL', 'b' ] )
+      end
+
+      it 'generates expected one-input-parameter output' do
+        result = described_class.cs_lt( :bar )
+        expect( result.call( 'a', 'b' ) ).to eq( [ 'bar < ? AND bar IS NOT NULL', 'b' ] )
+      end
+
+      it 'finds expected things' do
+        result = find( described_class.cs_lt.call( 'created_at', @tn ) )
+        expect( result ).to match_array( [ @t3, @t4, @t5, @t6 ] )
+
+        result = find( described_class.cs_lt.call( 'created_at', ( @tn - 2.months ) ) )
+        expect( result ).to match_array( [ @t5, @t6 ] )
+
+        result = find( described_class.cs_lt.call( 'created_at', ( @tn + 1.month ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4, @t5, @t6 ] )
+
+        result = find( described_class.cs_lt.call( 'created_at', ( @tn - 1.year ) ) )
+        expect( result ).to match_array( [] )
+
+        result = find( described_class.cs_lt.call( 'created_at', ( @tn - 2.years ) ) )
+        expect( result ).to match_array( [] )
+      end
+
+      it 'finds expected things negated' do
+        result = find_not( described_class.cs_lt.call( 'created_at', @tn ) )
+        expect( result ).to match_array( [ @t1, @t2, @t7 ] )
+
+        result = find_not( described_class.cs_lt.call( 'created_at', ( @tn - 2.months ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4, @t7 ] )
+
+        result = find_not( described_class.cs_lt.call( 'created_at', ( @tn + 1.month ) ) )
+        expect( result ).to match_array( [ @t7 ] )
+
+        result = find_not( described_class.cs_lt.call( 'created_at', ( @tn - 1.year ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4, @t5, @t6, @t7 ] )
+
+        result = find_not( described_class.cs_lt.call( 'created_at', ( @tn - 2.years ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4, @t5, @t6, @t7 ] )
+      end
     end
 
-    it 'finds expected things' do
-      result = find( described_class.cs_match_array.call( 'field', [ 'hello', 'world' ] ) )
-      expect( result ).to match_array( [ @f2, @f3, @f6, @f7 ] )
+    ###########################################################################
 
-      result = find( described_class.cs_match_array.call( 'field', [ 'HELLO', 'WORLD' ] ) )
-      expect( result ).to match_array( [ @f4, @f8 ] )
+    context '#cs_lte' do
+      it 'generates expected no-input-parameter output' do
+        result = described_class.cs_lte()
+        expect( result.call( 'a', 'b' ) ).to eq( [ 'a <= ? AND a IS NOT NULL', 'b' ] )
+      end
 
-      result = find( described_class.cs_match_array.call( 'field', [ 'hell', 'worl' ] ) )
-      expect( result ).to match_array( [] )
+      it 'generates expected one-input-parameter output' do
+        result = described_class.cs_lte( :bar )
+        expect( result.call( 'a', 'b' ) ).to eq( [ 'bar <= ? AND bar IS NOT NULL', 'b' ] )
+      end
 
-      result = find( described_class.cs_match_array.call( 'field', [ 'llo', 'ld' ] ) )
-      expect( result ).to match_array( [] )
+      it 'finds expected things' do
+        result = find( described_class.cs_lte.call( 'created_at', @tn ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4, @t5, @t6 ] )
 
-      result = find( described_class.cs_match_array.call( 'field', [ 'heLLo', 'WORld' ] ) )
-      expect( result ).to match_array( [] )
+        result = find( described_class.cs_lte.call( 'created_at', ( @tn - 2.months ) ) )
+        expect( result ).to match_array( [ @t5, @t6 ] )
+
+        result = find( described_class.cs_lte.call( 'created_at', ( @tn + 1.month ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4, @t5, @t6 ] )
+
+        result = find( described_class.cs_lte.call( 'created_at', ( @tn - 1.year ) ) )
+        expect( result ).to match_array( [ @t5, @t6 ] )
+
+        result = find( described_class.cs_lte.call( 'created_at', ( @tn - 2.years ) ) )
+        expect( result ).to match_array( [] )
+      end
+
+      it 'finds expected things negated' do
+        result = find_not( described_class.cs_lte.call( 'created_at', @tn ) )
+        expect( result ).to match_array( [ @t7 ] )
+
+        result = find_not( described_class.cs_lte.call( 'created_at', ( @tn - 2.months ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4, @t7 ] )
+
+        result = find_not( described_class.cs_lte.call( 'created_at', ( @tn + 1.month ) ) )
+        expect( result ).to match_array( [ @t7 ] )
+
+        result = find_not( described_class.cs_lte.call( 'created_at', ( @tn - 1.year ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4, @t7 ] )
+
+        result = find_not( described_class.cs_lte.call( 'created_at', ( @tn - 2.years ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4, @t5, @t6, @t7 ] )
+      end
     end
 
-    it 'finds expected things negated' do
-      result = find_not( described_class.cs_match_array.call( 'field', [ 'hello', 'world' ] ) )
-      expect( result ).to match_array( [ @f1,           @f4, @f5,          @f8 ] )
+    ###########################################################################
 
-      result = find_not( described_class.cs_match_array.call( 'field', [ 'HELLO', 'WORLD' ] ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3,      @f5, @f6, @f7      ] )
+    context '#cs_gt' do
+      it 'generates expected no-input-parameter output' do
+        result = described_class.cs_gt()
+        expect( result.call( 'a', 'b' ) ).to eq( [ 'a > ? AND a IS NOT NULL', 'b' ] )
+      end
 
-      result = find_not( described_class.cs_match_array.call( 'field', [ 'hell', 'worl' ] ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+      it 'generates expected one-input-parameter output' do
+        result = described_class.cs_gt( :bar )
+        expect( result.call( 'a', 'b' ) ).to eq( [ 'bar > ? AND bar IS NOT NULL', 'b' ] )
+      end
 
-      result = find_not( described_class.cs_match_array.call( 'field', [ 'llo', 'ld' ] ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
+      it 'finds expected things' do
+        result = find( described_class.cs_gt.call( 'created_at', @tn ) )
+        expect( result ).to match_array( [] )
 
-      result = find_not( described_class.cs_match_array.call( 'field', [ 'heLLo', 'WORld' ] ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
-    end
-  end
+        result = find( described_class.cs_gt.call( 'created_at', ( @tn - 2.months ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4 ] )
 
-  #############################################################################
+        result = find( described_class.cs_gt.call( 'created_at', ( @tn - 1.month ) ) )
+        expect( result ).to match_array( [ @t1, @t2 ] )
 
-  context '#ci_match_generic' do
-    it 'generates expected no-input-parameter output' do
-      result = described_class.ci_match_generic()
-      expect( result.call( 'a', 'B' ) ).to eq( [ 'lower(a) = ? AND a IS NOT NULL', 'b' ] )
-    end
+        result = find( described_class.cs_gt.call( 'created_at', ( @tn - 1.year ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4 ] )
 
-    it 'generates expected one-input-parameter output' do
-      result = described_class.ci_match_generic( :bar )
-      expect( result.call( 'a', 'B' ) ).to eq( [ 'lower(bar) = ? AND bar IS NOT NULL', 'b' ] )
-    end
+        result = find( described_class.cs_gt.call( 'created_at', ( @tn - 2.years ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4, @t5, @t6 ] )
+      end
 
-    it 'finds expected things' do
-      result = find( described_class.ci_match_generic.call( 'field', 'hello' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+      it 'finds expected things negated' do
+        result = find_not( described_class.cs_gt.call( 'created_at', @tn ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4, @t5, @t6, @t7 ] )
 
-      result = find( described_class.ci_match_generic.call( 'field', 'HELLO' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+        result = find_not( described_class.cs_gt.call( 'created_at', ( @tn - 2.months ) ) )
+        expect( result ).to match_array( [ @t5, @t6, @t7 ] )
 
-      result = find( described_class.ci_match_generic.call( 'field', 'hell' ) )
-      expect( result ).to match_array( [] )
+        result = find_not( described_class.cs_gt.call( 'created_at', ( @tn - 1.month ) ) )
+        expect( result ).to match_array( [ @t3, @t4, @t5, @t6, @t7 ] )
 
-      result = find( described_class.ci_match_generic.call( 'field', 'llo' ) )
-      expect( result ).to match_array( [] )
+        result = find_not( described_class.cs_gt.call( 'created_at', ( @tn - 1.year ) ) )
+        expect( result ).to match_array( [ @t5, @t6, @t7 ] )
 
-      result = find( described_class.ci_match_generic.call( 'field', 'heLLo' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
-    end
-
-    it 'finds expected things negated' do
-      result = find_not( described_class.ci_match_generic.call( 'field', 'hello' ) )
-      expect( result ).to match_array( [ @f1,                @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ci_match_generic.call( 'field', 'HELLO' ) )
-      expect( result ).to match_array( [ @f1,                @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ci_match_generic.call( 'field', 'hell' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ci_match_generic.call( 'field', 'llo' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ci_match_generic.call( 'field', 'heLLo' ) )
-      expect( result ).to match_array( [ @f1,                @f5, @f6, @f7, @f8 ] )
-    end
-  end
-
-  #############################################################################
-
-  context '#ciaw_match_generic' do
-    it 'generates expected no-input-parameter output' do
-      result = described_class.ciaw_match_generic()
-      expect( result.call( 'a', 'B' ) ).to eq( [ 'lower(a) LIKE ? AND a IS NOT NULL', '%b%' ] )
+        result = find_not( described_class.cs_gt.call( 'created_at', ( @tn - 2.years ) ) )
+        expect( result ).to match_array( [ @t7 ] )
+      end
     end
 
-    it 'generates expected one-input-parameter output' do
-      result = described_class.ciaw_match_generic( :bar )
-      expect( result.call( 'a', 'B' ) ).to eq( [ 'lower(bar) LIKE ? AND bar IS NOT NULL', '%b%' ] )
+    ###########################################################################
+
+    context '#cs_gte' do
+      it 'generates expected no-input-parameter output' do
+        result = described_class.cs_gte()
+        expect( result.call( 'a', 'b' ) ).to eq( [ 'a >= ? AND a IS NOT NULL', 'b' ] )
+      end
+
+      it 'generates expected one-input-parameter output' do
+        result = described_class.cs_gte( :bar )
+        expect( result.call( 'a', 'b' ) ).to eq( [ 'bar >= ? AND bar IS NOT NULL', 'b' ] )
+      end
+
+      it 'finds expected things' do
+        result = find( described_class.cs_gte.call( 'created_at', @tn ) )
+        expect( result ).to match_array( [ @t1, @t2 ] )
+
+        result = find( described_class.cs_gte.call( 'created_at', ( @tn - 2.months ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4 ] )
+
+        result = find( described_class.cs_gte.call( 'created_at', ( @tn - 1.month ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4 ] )
+
+        result = find( described_class.cs_gte.call( 'created_at', ( @tn - 1.year ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4, @t5, @t6 ] )
+
+        result = find( described_class.cs_gte.call( 'created_at', ( @tn - 2.years ) ) )
+        expect( result ).to match_array( [ @t1, @t2, @t3, @t4, @t5, @t6 ] )
+      end
+
+      it 'finds expected things negated' do
+        result = find_not( described_class.cs_gte.call( 'created_at', @tn ) )
+        expect( result ).to match_array( [ @t3, @t4, @t5, @t6, @t7 ] )
+
+        result = find_not( described_class.cs_gte.call( 'created_at', ( @tn - 2.months ) ) )
+        expect( result ).to match_array( [ @t5, @t6, @t7 ] )
+
+        result = find_not( described_class.cs_gte.call( 'created_at', ( @tn - 1.month ) ) )
+        expect( result ).to match_array( [ @t5, @t6, @t7 ] )
+
+        result = find_not( described_class.cs_gte.call( 'created_at', ( @tn - 1.year ) ) )
+        expect( result ).to match_array( [ @t7 ] )
+
+        result = find_not( described_class.cs_gte.call( 'created_at', ( @tn - 2.years ) ) )
+        expect( result ).to match_array( [ @t7 ] )
+      end
     end
 
-    it 'finds expected things' do
-      result = find( described_class.ciaw_match_generic.call( 'field', 'hello' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
+    ###########################################################################
 
-      result = find( described_class.ciaw_match_generic.call( 'field', 'HELLO' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
-
-      result = find( described_class.ciaw_match_generic.call( 'field', 'hell' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
-
-      result = find( described_class.ciaw_match_generic.call( 'field', 'llo' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
-
-      result = find( described_class.ciaw_match_generic.call( 'field', 'heLLo' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
-    end
-
-    it 'finds expected things negated' do
-      result = find_not( described_class.ciaw_match_generic.call( 'field', 'hello' ) )
-      expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ciaw_match_generic.call( 'field', 'HELLO' ) )
-      expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ciaw_match_generic.call( 'field', 'hell' ) )
-      expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ciaw_match_generic.call( 'field', 'llo' ) )
-      expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ciaw_match_generic.call( 'field', 'heLLo' ) )
-      expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
-    end
-  end
-
-  #############################################################################
-
-  context '#csaw_match' do
-    it 'generates expected no-input-parameter output' do
-      result = described_class.csaw_match()
-      expect( result.call( 'a', 'B' ) ).to eq( [ 'a LIKE ? AND a IS NOT NULL', '%B%' ] )
-    end
-
-    it 'generates expected one-input-parameter output' do
-      result = described_class.csaw_match( :bar )
-      expect( result.call( 'a', 'B' ) ).to eq( [ 'bar LIKE ? AND bar IS NOT NULL', '%B%' ] )
-    end
-
-    it 'finds expected things' do
-      result = find( described_class.csaw_match.call( 'field', 'hello' ) )
-      expect( result ).to match_array( [ @f2, @f3 ] )
-
-      result = find( described_class.csaw_match.call( 'field', 'HELLO' ) )
-      expect( result ).to match_array( [ @f4 ] )
-
-      result = find( described_class.csaw_match.call( 'field', 'hell' ) )
-      expect( result ).to match_array( [ @f2, @f3 ] )
-
-      result = find( described_class.csaw_match.call( 'field', 'llo' ) )
-      expect( result ).to match_array( [ @f2, @f3 ] )
-
-      result = find( described_class.csaw_match.call( 'field', 'heLLo' ) )
-      expect( result ).to match_array( [  ] )
-    end
-
-    it 'finds expected things negated' do
-      result = find_not( described_class.csaw_match.call( 'field', 'hello' ) )
-      expect( result ).to match_array( [ @f1, @f4, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.csaw_match.call( 'field', 'HELLO' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.csaw_match.call( 'field', 'hell' ) )
-      expect( result ).to match_array( [ @f1, @f4, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.csaw_match.call( 'field', 'llo' ) )
-      expect( result ).to match_array( [ @f1, @f4, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.csaw_match.call( 'field', 'heLLo' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
-    end
-  end
-
-  #############################################################################
-
-  context '#ci_match_postgres' do
-    it 'generates expected no-input-parameter output' do
-      result = described_class.ci_match_postgres()
-      expect( result.call( 'a', 'B' ) ).to eq( [ 'a ILIKE ? AND a IS NOT NULL', 'B' ] )
-    end
-
-    it 'generates expected one-input-parameter output' do
-      result = described_class.ci_match_postgres( :bar )
-      expect( result.call( 'a', 'B' ) ).to eq( [ 'bar ILIKE ? AND bar IS NOT NULL', 'B' ] )
-    end
-
-    it 'finds expected things' do
-      result = find( described_class.ci_match_postgres.call( 'field', 'hello' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
-
-      result = find( described_class.ci_match_postgres.call( 'field', 'HELLO' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
-
-      result = find( described_class.ci_match_postgres.call( 'field', 'hell' ) )
-      expect( result ).to match_array( [] )
-
-      result = find( described_class.ci_match_postgres.call( 'field', 'llo' ) )
-      expect( result ).to match_array( [] )
-
-      result = find( described_class.ci_match_postgres.call( 'field', 'heLLo' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
-    end
-
-    it 'finds expected things negated' do
-      result = find_not( described_class.ci_match_postgres.call( 'field', 'hello' ) )
-      expect( result ).to match_array( [ @f1,                @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ci_match_postgres.call( 'field', 'HELLO' ) )
-      expect( result ).to match_array( [ @f1,                @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ci_match_postgres.call( 'field', 'hell' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ci_match_postgres.call( 'field', 'llo' ) )
-      expect( result ).to match_array( [ @f1, @f2, @f3, @f4, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ci_match_postgres.call( 'field', 'heLLo' ) )
-      expect( result ).to match_array( [ @f1,                @f5, @f6, @f7, @f8 ] )
-    end
-  end
-
-  #############################################################################
-
-  context '#ciaw_match_postgres' do
-    it 'generates expected no-input-parameter output' do
-      result = described_class.ciaw_match_postgres()
-      expect( result.call( 'a', 'B' ) ).to eq( [ 'a ILIKE ? AND a IS NOT NULL', '%B%' ] )
-    end
-
-    it 'generates expected one-input-parameter output' do
-      result = described_class.ciaw_match_postgres( :bar )
-      expect( result.call( 'a', 'B' ) ).to eq( [ 'bar ILIKE ? AND bar IS NOT NULL', '%B%' ] )
-    end
-
-    it 'finds expected things' do
-      result = find( described_class.ciaw_match_postgres.call( 'field', 'hello' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
-
-      result = find( described_class.ciaw_match_postgres.call( 'field', 'HELLO' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
-
-      result = find( described_class.ciaw_match_postgres.call( 'field', 'hell' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
-
-      result = find( described_class.ciaw_match_postgres.call( 'field', 'llo' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
-
-      result = find( described_class.ciaw_match_postgres.call( 'field', 'heLLo' ) )
-      expect( result ).to match_array( [ @f2, @f3, @f4 ] )
-    end
-
-    it 'finds expected things negated' do
-      result = find_not( described_class.ciaw_match_postgres.call( 'field', 'hello' ) )
-      expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ciaw_match_postgres.call( 'field', 'HELLO' ) )
-      expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ciaw_match_postgres.call( 'field', 'hell' ) )
-      expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ciaw_match_postgres.call( 'field', 'llo' ) )
-      expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
-
-      result = find_not( described_class.ciaw_match_postgres.call( 'field', 'heLLo' ) )
-      expect( result ).to match_array( [ @f1, @f5, @f6, @f7, @f8 ] )
-    end
   end
 end

--- a/spec/active/active_record/support_spec.rb
+++ b/spec/active/active_record/support_spec.rb
@@ -1,6 +1,28 @@
 require 'spec_helper.rb'
 
 describe Hoodoo::ActiveRecord::Support do
+  context '#framework_search_and_filter_data' do
+    it 'returns the expected number of keys' do
+      hash = described_class.framework_search_and_filter_data()
+      expect( hash.keys.count ).to eq( Hoodoo::Services::Middleware::FRAMEWORK_QUERY_DATA.keys.count )
+    end
+
+    it 'complains if there is a mismatch' do
+      middleware = Hoodoo::Services::Middleware
+      old_value  = middleware.const_get( 'FRAMEWORK_QUERY_DATA' )
+
+      middleware.send( :remove_const, 'FRAMEWORK_QUERY_DATA' )
+      middleware.const_set( 'FRAMEWORK_QUERY_DATA', old_value.merge( { Hoodoo::UUID.generate() => 1 } ) )
+
+      expect {
+        described_class.framework_search_and_filter_data()
+      }.to raise_error( RuntimeError, 'Hoodoo::ActiveRecord::Support#framework_search_and_filter_data: Mismatch between internal mapping and Hoodoo::Services::Middleware::FRAMEWORK_QUERY_DATA' )
+
+      middleware.send( :remove_const, 'FRAMEWORK_QUERY_DATA' )
+      middleware.const_set( 'FRAMEWORK_QUERY_DATA', old_value )
+    end
+  end
+
   context '#self.process_to_map' do
     it 'processes as expected' do
       proc1 = Proc.new { puts "hello" }

--- a/spec/services/middleware/middleware_spec.rb
+++ b/spec/services/middleware/middleware_spec.rb
@@ -854,11 +854,12 @@ describe Hoodoo::Services::Middleware do
       end
 
       it 'should respond to permitted framework search query parameter' do
-        str    = Time.now.iso8601
+        dt     = DateTime.parse( Time.now.round.iso8601 )
+        str    = dt.iso8601
         encstr = CGI.escape( CGI.escape( str ) ) # Remember, search values within the subquery string must be double escaped
 
         expect_any_instance_of(RSpecTestServiceStubImplementation).to receive(:list).once do | ignored_rspec_mock_instance, context |
-          expect(context.request.list.search_data).to eq({'created_after' => str})
+          expect(context.request.list.search_data).to eq({'created_after' => dt})
         end
 
         get "/v2/rspec_test_service_stub?search=created_after%3D#{ encstr }", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
@@ -946,11 +947,12 @@ describe Hoodoo::Services::Middleware do
       end
 
       it 'should respond to permitted framework filter query parameter' do
-        str    = Time.now.iso8601
+        dt     = DateTime.parse( Time.now.round.iso8601 )
+        str    = dt.iso8601
         encstr = CGI.escape( CGI.escape( str ) ) # Remember, search values within the subquery string must be double escaped
 
         expect_any_instance_of(RSpecTestServiceStubImplementation).to receive(:list).once do | ignored_rspec_mock_instance, context |
-          expect(context.request.list.filter_data).to eq({'created_on_or_before' => str})
+          expect(context.request.list.filter_data).to eq({'created_on_or_before' => dt})
         end
 
         get "/v2/rspec_test_service_stub?filter=created_on_or_before%3D#{ encstr }", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }

--- a/spec/services/middleware/middleware_spec.rb
+++ b/spec/services/middleware/middleware_spec.rb
@@ -33,6 +33,8 @@ class RSpecTestServiceStubInterface < Hoodoo::Services::Interface
       sort :conventional => [:asc, :desc]
       search :foo, :bar
       filter :baz, :boo
+      do_not_search :created_on_or_before
+      do_not_filter :created_after
     end
     to_create do
       text :foo, :required => true
@@ -851,6 +853,41 @@ describe Hoodoo::Services::Middleware do
         expect(result['errors'][0]['reference']).to eq('search: thing\\, thang')
       end
 
+      it 'should respond to permitted framework search query parameter' do
+        str    = Time.now.iso8601
+        encstr = CGI.escape( CGI.escape( str ) ) # Remember, search values within the subquery string must be double escaped
+
+        expect_any_instance_of(RSpecTestServiceStubImplementation).to receive(:list).once do | ignored_rspec_mock_instance, context |
+          expect(context.request.list.search_data).to eq({'created_after' => str})
+        end
+
+        get "/v2/rspec_test_service_stub?search=created_after%3D#{ encstr }", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'should reject malformed value in permitted framework search query parameter' do
+        expect_any_instance_of(RSpecTestServiceStubImplementation).to_not receive(:list)
+        get "/v2/rspec_test_service_stub?search=created_after%3Dthing", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
+        expect(last_response.status).to eq(422)
+        result = JSON.parse(last_response.body)
+        expect(result['errors'][0]['code']).to eq('platform.malformed')
+        expect(result['errors'][0]['message']).to eq('One or more malformed or invalid query string parameters')
+        expect(result['errors'][0]['reference']).to eq('search: created_after')
+      end
+
+      it 'should reject prohibited framework search query parameter' do
+        str    = Time.now.iso8601
+        encstr = CGI.escape( CGI.escape( str ) ) # Remember, search values within the subquery string must be double escaped
+
+        expect_any_instance_of(RSpecTestServiceStubImplementation).to_not receive(:list)
+        get "/v2/rspec_test_service_stub?search=created_on_or_before%3D#{ encstr }", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
+        expect(last_response.status).to eq(422)
+        result = JSON.parse(last_response.body)
+        expect(result['errors'][0]['code']).to eq('platform.malformed')
+        expect(result['errors'][0]['message']).to eq('One or more malformed or invalid query string parameters')
+        expect(result['errors'][0]['reference']).to eq('search: created_on_or_before')
+      end
+
       it 'should respond to filter query parameter (form 1)' do
         expect_any_instance_of(RSpecTestServiceStubImplementation).to receive(:list).once do | ignored_rspec_mock_instance, context |
           expect(context.request.list.filter_data).to eq({'baz' => 'more', 'boo' => 'val'})
@@ -906,6 +943,41 @@ describe Hoodoo::Services::Middleware do
         expect(result['errors'][0]['code']).to eq('platform.malformed')
         expect(result['errors'][0]['message']).to eq('One or more malformed or invalid query string parameters')
         expect(result['errors'][0]['reference']).to eq('filter: thung\\, theng')
+      end
+
+      it 'should respond to permitted framework filter query parameter' do
+        str    = Time.now.iso8601
+        encstr = CGI.escape( CGI.escape( str ) ) # Remember, search values within the subquery string must be double escaped
+
+        expect_any_instance_of(RSpecTestServiceStubImplementation).to receive(:list).once do | ignored_rspec_mock_instance, context |
+          expect(context.request.list.filter_data).to eq({'created_on_or_before' => str})
+        end
+
+        get "/v2/rspec_test_service_stub?filter=created_on_or_before%3D#{ encstr }", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'should reject malformed value in permitted framework filter query parameter' do
+        expect_any_instance_of(RSpecTestServiceStubImplementation).to_not receive(:list)
+        get "/v2/rspec_test_service_stub?filter=created_on_or_before%3Dthing", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
+        expect(last_response.status).to eq(422)
+        result = JSON.parse(last_response.body)
+        expect(result['errors'][0]['code']).to eq('platform.malformed')
+        expect(result['errors'][0]['message']).to eq('One or more malformed or invalid query string parameters')
+        expect(result['errors'][0]['reference']).to eq('filter: created_on_or_before')
+      end
+
+      it 'should reject prohibited framework filter query parameter' do
+        str    = Time.now.iso8601
+        encstr = CGI.escape( CGI.escape( str ) ) # Remember, search values within the subquery string must be double escaped
+
+        expect_any_instance_of(RSpecTestServiceStubImplementation).to_not receive(:list)
+        get "/v2/rspec_test_service_stub?filter=created_after%3D#{ encstr }", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
+        expect(last_response.status).to eq(422)
+        result = JSON.parse(last_response.body)
+        expect(result['errors'][0]['code']).to eq('platform.malformed')
+        expect(result['errors'][0]['message']).to eq('One or more malformed or invalid query string parameters')
+        expect(result['errors'][0]['reference']).to eq('filter: created_after')
       end
 
       it 'should respond to embed query parameter' do

--- a/spec/services/middleware/middleware_spec.rb
+++ b/spec/services/middleware/middleware_spec.rb
@@ -33,7 +33,7 @@ class RSpecTestServiceStubInterface < Hoodoo::Services::Interface
       sort :conventional => [:asc, :desc]
       search :foo, :bar
       filter :baz, :boo
-      do_not_search :created_on_or_before
+      do_not_search :created_before
       do_not_filter :created_after
     end
     to_create do
@@ -881,12 +881,12 @@ describe Hoodoo::Services::Middleware do
         encstr = CGI.escape( CGI.escape( str ) ) # Remember, search values within the subquery string must be double escaped
 
         expect_any_instance_of(RSpecTestServiceStubImplementation).to_not receive(:list)
-        get "/v2/rspec_test_service_stub?search=created_on_or_before%3D#{ encstr }", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
+        get "/v2/rspec_test_service_stub?search=created_before%3D#{ encstr }", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
         expect(last_response.status).to eq(422)
         result = JSON.parse(last_response.body)
         expect(result['errors'][0]['code']).to eq('platform.malformed')
         expect(result['errors'][0]['message']).to eq('One or more malformed or invalid query string parameters')
-        expect(result['errors'][0]['reference']).to eq('search: created_on_or_before')
+        expect(result['errors'][0]['reference']).to eq('search: created_before')
       end
 
       it 'should respond to filter query parameter (form 1)' do
@@ -952,21 +952,21 @@ describe Hoodoo::Services::Middleware do
         encstr = CGI.escape( CGI.escape( str ) ) # Remember, search values within the subquery string must be double escaped
 
         expect_any_instance_of(RSpecTestServiceStubImplementation).to receive(:list).once do | ignored_rspec_mock_instance, context |
-          expect(context.request.list.filter_data).to eq({'created_on_or_before' => dt})
+          expect(context.request.list.filter_data).to eq({'created_before' => dt})
         end
 
-        get "/v2/rspec_test_service_stub?filter=created_on_or_before%3D#{ encstr }", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
+        get "/v2/rspec_test_service_stub?filter=created_before%3D#{ encstr }", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
         expect(last_response.status).to eq(200)
       end
 
       it 'should reject malformed value in permitted framework filter query parameter' do
         expect_any_instance_of(RSpecTestServiceStubImplementation).to_not receive(:list)
-        get "/v2/rspec_test_service_stub?filter=created_on_or_before%3Dthing", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
+        get "/v2/rspec_test_service_stub?filter=created_before%3Dthing", nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
         expect(last_response.status).to eq(422)
         result = JSON.parse(last_response.body)
         expect(result['errors'][0]['code']).to eq('platform.malformed')
         expect(result['errors'][0]['message']).to eq('One or more malformed or invalid query string parameters')
-        expect(result['errors'][0]['reference']).to eq('filter: created_on_or_before')
+        expect(result['errors'][0]['reference']).to eq('filter: created_before')
       end
 
       it 'should reject prohibited framework filter query parameter' do

--- a/spec/services/services/interface_spec.rb
+++ b/spec/services/services/interface_spec.rb
@@ -18,6 +18,8 @@ class RSpecTestInterfaceInterfaceA < Hoodoo::Services::Interface
       sort   :sort_one => [ :left, :right ], default( :sort_two ) => [ :up, :down ]
       search :search_one, :search_two, :search_three
       filter :filter_one, :filter_two, :filter_three
+      do_not_search :created_after, :created_on_or_before
+      do_not_filter :created_after
     end
 
     to_create do
@@ -74,6 +76,8 @@ describe Hoodoo::Services::Interface do
       expect(RSpecTestInterfaceInterfaceDefault.to_list.default_sort_direction).to eq('desc')
       expect(RSpecTestInterfaceInterfaceDefault.to_list.search).to be_empty
       expect(RSpecTestInterfaceInterfaceDefault.to_list.filter).to be_empty
+      expect(RSpecTestInterfaceInterfaceDefault.to_list.do_not_search).to be_empty
+      expect(RSpecTestInterfaceInterfaceDefault.to_list.do_not_filter).to be_empty
       expect(RSpecTestInterfaceInterfaceDefault.to_create).to be_nil
       expect(RSpecTestInterfaceInterfaceDefault.to_update).to be_nil
     end
@@ -94,6 +98,8 @@ describe Hoodoo::Services::Interface do
       expect(RSpecTestInterfaceInterfaceA.to_list.default_sort_direction).to eq('up')
       expect(RSpecTestInterfaceInterfaceA.to_list.search).to eq(['search_one', 'search_two', 'search_three'])
       expect(RSpecTestInterfaceInterfaceA.to_list.filter).to eq(['filter_one', 'filter_two', 'filter_three'])
+      expect(RSpecTestInterfaceInterfaceA.to_list.do_not_search).to eq(['created_after', 'created_on_or_before'])
+      expect(RSpecTestInterfaceInterfaceA.to_list.do_not_filter).to eq(['created_after'])
       expect(RSpecTestInterfaceInterfaceA.to_create).to_not be_nil
       expect(RSpecTestInterfaceInterfaceA.to_create.get_schema().properties['foo']).to be_a(Hoodoo::Presenters::Text)
       expect(RSpecTestInterfaceInterfaceA.to_create.get_schema().properties['bar']).to be_a(Hoodoo::Presenters::Enum)

--- a/spec/services/services/interface_spec.rb
+++ b/spec/services/services/interface_spec.rb
@@ -264,5 +264,25 @@ describe Hoodoo::Services::Interface do
         }.to raise_error(RuntimeError, "Hoodoo::Services::Interface::ToListDSL\#default requires a String or Symbol - got 'Fixnum'")
       end
     end
+
+    context 'in #do_not_search' do
+      it 'should complain about unknown keys' do
+        expect {
+          Hoodoo::Services::Interface::ToListDSL.new( Hoodoo::Services::Interface::ToList.new ) do
+            do_not_search 'foo', 'bar'
+          end
+        }.to raise_error(RuntimeError, "Hoodoo::Services::Interface::ToListDSL\#do_not_search was given one or more unknown keys: foo, bar")
+      end
+    end
+
+    context 'in #do_not_filter' do
+      it 'should complain about unknown keys' do
+        expect {
+          Hoodoo::Services::Interface::ToListDSL.new( Hoodoo::Services::Interface::ToList.new ) do
+            do_not_filter 'baz', 'boo'
+          end
+        }.to raise_error(RuntimeError, "Hoodoo::Services::Interface::ToListDSL\#do_not_filter was given one or more unknown keys: baz, boo")
+      end
+    end
   end
 end

--- a/spec/services/services/interface_spec.rb
+++ b/spec/services/services/interface_spec.rb
@@ -18,7 +18,7 @@ class RSpecTestInterfaceInterfaceA < Hoodoo::Services::Interface
       sort   :sort_one => [ :left, :right ], default( :sort_two ) => [ :up, :down ]
       search :search_one, :search_two, :search_three
       filter :filter_one, :filter_two, :filter_three
-      do_not_search :created_after, :created_on_or_before
+      do_not_search :created_after, :created_before
       do_not_filter :created_after
     end
 
@@ -98,7 +98,7 @@ describe Hoodoo::Services::Interface do
       expect(RSpecTestInterfaceInterfaceA.to_list.default_sort_direction).to eq('up')
       expect(RSpecTestInterfaceInterfaceA.to_list.search).to eq(['search_one', 'search_two', 'search_three'])
       expect(RSpecTestInterfaceInterfaceA.to_list.filter).to eq(['filter_one', 'filter_two', 'filter_three'])
-      expect(RSpecTestInterfaceInterfaceA.to_list.do_not_search).to eq(['created_after', 'created_on_or_before'])
+      expect(RSpecTestInterfaceInterfaceA.to_list.do_not_search).to eq(['created_after', 'created_before'])
       expect(RSpecTestInterfaceInterfaceA.to_list.do_not_filter).to eq(['created_after'])
       expect(RSpecTestInterfaceInterfaceA.to_create).to_not be_nil
       expect(RSpecTestInterfaceInterfaceA.to_create.get_schema().properties['foo']).to be_a(Hoodoo::Presenters::Text)


### PR DESCRIPTION
Support for default _opt-out_ framework-wide search/filter strings of `created_after` (for `created_at` timestamps after a particular given date/time) and `created_before` (self explanatory!).

Addresses #109.

One or two minor drive-by fixes included, such as removing the `dry_proc` in the search core code which wasn't really DRYing things much and obfuscated the code's operation quite badly.

RDoc comments have been reviewed and checked against RDoc output but the actual generated docs are not included in this PR for clarity and will follow in the subsequent version number bump PR once this the main change set is reviewed, agreed and merged.