### PR TITLE
Feature/new relic patch coverage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,15 +56,15 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.5)
     erubis (2.7.0)
-    eventmachine (1.2.0.1)
+    eventmachine (1.2.1)
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
     json (1.8.3)
     kgio (2.10.0)
-    le (2.7.2)
-    minitest (5.9.0)
+    le (2.7.4)
+    minitest (5.10.1)
     multi_json (1.12.1)
     multi_xml (0.5.5)
     pg (0.19.0)
@@ -76,13 +76,12 @@ GEM
       httparty (~> 0.13.7)
       json
       rack
-    rdoc (4.2.2)
-      json (~> 1.4)
+    rdoc (4.3.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
       rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.3)
+    rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -130,4 +129,4 @@ DEPENDENCIES
   timecop (~> 0.8)
 
 BUNDLED WITH
-   1.12.5
+   1.13.2

--- a/spec/monkey/patch/newrelic_middleware_analytics_spec.rb
+++ b/spec/monkey/patch/newrelic_middleware_analytics_spec.rb
@@ -3,13 +3,58 @@ require 'spec_helper.rb'
 # This is little more than a coverage exercise.
 
 describe Hoodoo::Monkey::Patch::NewRelicMiddlewareAnalytics do
-  context 'InstanceExtensions' do
-    class NewRelicInstanceExtensionsTest
-      include Hoodoo::Monkey::Patch::NewRelicMiddlewareAnalytics::InstanceExtensions
+
+  class RSpecTestNRMAImplementation < Hoodoo::Services::Implementation
+    def list( context ); end
+  end
+
+  class RSpecTestNRMAInterface < Hoodoo::Services::Interface
+    interface :RSpecTestNRMA do
+      endpoint :rspec_test_nrma, RSpecTestNRMAImplementation
+    end
+  end
+
+  class RSpecTestNRMAService < Hoodoo::Services::Service
+    comprised_of RSpecTestNRMAInterface
+  end
+
+  def app
+    Rack::Builder.new do
+      use Hoodoo::Services::Middleware
+      run RSpecTestNRMAService.new
+    end
+  end
+
+  before :all do
+    $endpoint_monkey_log_inbound_request_count = 0
+
+    module NewRelic
+      module Agent
+        extend self
+        def add_custom_attributes( params )
+          $endpoint_monkey_log_inbound_request_count += 1
+        end
+      end
     end
 
-    it 'call NewRelic' do
-      Hoodoo::Monkey::Patch::NewRelicMiddlewareAnalytics::InstanceExtensions.monkey_log_inbound_request()
-    end
+    Hoodoo::Monkey.enable( extension_module: Hoodoo::Monkey::Patch::NewRelicMiddlewareAnalytics )
+  end
+
+  after :all do
+    Hoodoo::Monkey.disable( extension_module: Hoodoo::Monkey::Patch::NewRelicMiddlewareAnalytics )
+    Object.send( :remove_const, :NewRelic )
+  end
+
+  before :each do
+    expect( Hoodoo::Services::Middleware.ancestors ).to include( Hoodoo::Monkey::Patch::NewRelicMiddlewareAnalytics::InstanceExtensions )
+  end
+
+  it 'calls the NewRelic patch' do
+    get '/v1/rspec_test_nrma', nil, { 'CONTENT_TYPE' => 'application/json; charset=utf-8' }
+    expect( last_response.status ).to eq( 200 )
+
+    # We expect two log calls; secure inbound and normal inbound.
+    #
+    expect( $endpoint_monkey_log_inbound_request_count ).to eq( 2 )
   end
 end

--- a/spec/monkey/patch/newrelic_middleware_analytics_spec.rb
+++ b/spec/monkey/patch/newrelic_middleware_analytics_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper.rb'
+
+# This is little more than a coverage exercise.
+
+describe Hoodoo::Monkey::Patch::NewRelicMiddlewareAnalytics do
+  context 'InstanceExtensions' do
+    class NewRelicInstanceExtensionsTest
+      include Hoodoo::Monkey::Patch::NewRelicMiddlewareAnalytics::InstanceExtensions
+    end
+
+    it 'call NewRelic' do
+      Hoodoo::Monkey::Patch::NewRelicMiddlewareAnalytics::InstanceExtensions.monkey_log_inbound_request()
+    end
+  end
+end

--- a/spec/monkey/patch/newrelic_traced_amqp_spec.rb
+++ b/spec/monkey/patch/newrelic_traced_amqp_spec.rb
@@ -19,7 +19,7 @@ describe Hoodoo::Monkey::Patch::NewRelicTracedAMQP, :order => :defined do
     @@newrelic_agent_disable_count = 0
 
     module NewRelic
-      class Agent
+      module Agent
         class CrossAppTracing
         end
       end
@@ -127,7 +127,7 @@ describe Hoodoo::Monkey::Patch::NewRelicTracedAMQP::AMQPNewRelicResponseWrapper 
 
   before :all do
     module NewRelic
-      class Agent
+      module Agent
         class CrossAppTracing
           NR_APPDATA_HEADER = 'X_Foo_AppData'
         end

--- a/spec/new_relic/agent/method_tracer.rb
+++ b/spec/new_relic/agent/method_tracer.rb
@@ -1,0 +1,10 @@
+########################################################################
+# File::    method_tracer.rb
+# (C)::     Loyalty New Zealand 2016
+#
+# Purpose:: Override NewRelic 'new_relic/agent/method_tracer'. See the
+#           top level 'spec/newrelic_rpm.rb' file for details.
+# ----------------------------------------------------------------------
+#           02-Dec-2016 (ADH): Created.
+########################################################################
+

--- a/spec/new_relic/agent/method_tracer.rb
+++ b/spec/new_relic/agent/method_tracer.rb
@@ -8,3 +8,28 @@
 #           02-Dec-2016 (ADH): Created.
 ########################################################################
 
+# Note that all of this will be defined when the test suite is starting up, but
+# during test runs, local redefinitions of NewRelic and *undefinitions* of that
+# constant will occur. The code only exists so that other "require"s will work
+# and thus provide coverage, mainly inside "newrelic_middleware_analytics.rb".
+#
+module NewRelic
+  module Agent
+    module MethodTracer
+
+      def self.included( klass )
+        klass.extend( ClassMethods )
+      end
+
+      module ClassMethods
+        module AddMethodTracer
+          def add_method_tracer( method_name, metric_name_code = nil, options = {} )
+          end
+        end
+
+        include AddMethodTracer
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Extended NewRelic tracing was added to Hoodoo a long time ago, but full automated test coverage was never included because it's fiddly and, in practice, not a very deep test. But it's still non-zero coverage, would detect basic code rot and means that Hoodoo is no longer breaking its own rules about never accepting commits without a clean bill of health from RCov.