### PR TITLE
Hopefully final hotfix for Hoodoo::...::Base subclasses and search-with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 1.12.1 (2016-12-07)
+## 1.12.1, 1.12.2 (2016-12-07)
 
 * Test coverage on 1.12.0 overlooked the case where a model defines no search or filter data at all - no calls are made to `search_with` or `filter_with`. In that case, the framework search keys wouldn't be applied. Test coverage added and bug fixed.
+
+* Ensure that with the above fix in place, both subclasses of `Hoodoo::ActiveRecord::Base` and classes explicitly including the Finder module work with both framework-only and custom declarations of search and filter directives.
 
 ## 1.12.0 (2016-12-06)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    hoodoo (1.12.1)
+    hoodoo (1.12.2)
       dalli (~> 2.7)
       kgio (~> 2.9)
 

--- a/docs/rdoc/classes/Hoodoo.html
+++ b/docs/rdoc/classes/Hoodoo.html
@@ -1255,7 +1255,7 @@ thing.</p>
           <tr valign='top' id='VERSION'>
             <td class="attr-name">VERSION</td>
             <td>=</td>
-            <td class="attr-value"><pre>&#39;1.12.1&#39;</pre></td>
+            <td class="attr-value"><pre>&#39;1.12.2&#39;</pre></td>
           </tr>
             <tr valign='top'>
               <td>&nbsp;</td>

--- a/docs/rdoc/classes/Hoodoo/ActiveRecord/Finder.html
+++ b/docs/rdoc/classes/Hoodoo/ActiveRecord/Finder.html
@@ -158,9 +158,6 @@ this module.</p>
   <span class="ruby-keyword">unless</span> <span class="ruby-identifier">model</span> <span class="ruby-operator">==</span> <span class="ruby-constant">Hoodoo</span><span class="ruby-operator">::</span><span class="ruby-constant">ActiveRecord</span><span class="ruby-operator">::</span><span class="ruby-constant">Base</span>
     <span class="ruby-identifier">model</span>.<span class="ruby-identifier">send</span>( <span class="ruby-value">:include</span>, <span class="ruby-constant">Hoodoo</span><span class="ruby-operator">::</span><span class="ruby-constant">ActiveRecord</span><span class="ruby-operator">::</span><span class="ruby-constant">Secure</span> )
     <span class="ruby-identifier">instantiate</span>( <span class="ruby-identifier">model</span> )
-
-    <span class="ruby-identifier">model</span>.<span class="ruby-identifier">nz_co_loyalty_hoodoo_search_with</span> = <span class="ruby-constant">Hoodoo</span><span class="ruby-operator">::</span><span class="ruby-constant">ActiveRecord</span><span class="ruby-operator">::</span><span class="ruby-constant">Support</span>.<span class="ruby-identifier">framework_search_and_filter_data</span>()
-    <span class="ruby-identifier">model</span>.<span class="ruby-identifier">nz_co_loyalty_hoodoo_filter_with</span> = <span class="ruby-constant">Hoodoo</span><span class="ruby-operator">::</span><span class="ruby-constant">ActiveRecord</span><span class="ruby-operator">::</span><span class="ruby-constant">Support</span>.<span class="ruby-identifier">framework_search_and_filter_data</span>()
   <span class="ruby-keyword">end</span>
 
   <span class="ruby-keyword">super</span>( <span class="ruby-identifier">model</span> )
@@ -198,9 +195,12 @@ this module.</p>
                 <a href="javascript:toggleSource('method-c-instantiate_source')" id="l_method-c-instantiate_source">show</a>
               </p>
               <div id="method-c-instantiate_source" class="dyn-source">
-                <pre><span class="ruby-comment"># File lib/hoodoo/active/active_record/finder.rb, line 86</span>
+                <pre><span class="ruby-comment"># File lib/hoodoo/active/active_record/finder.rb, line 83</span>
 <span class="ruby-keyword">def</span> <span class="ruby-keyword ruby-title">self</span>.<span class="ruby-identifier">instantiate</span>( <span class="ruby-identifier">model</span> )
   <span class="ruby-identifier">model</span>.<span class="ruby-identifier">extend</span>( <span class="ruby-constant">ClassMethods</span> )
+
+  <span class="ruby-identifier">model</span>.<span class="ruby-identifier">nz_co_loyalty_hoodoo_search_with</span> = <span class="ruby-constant">Hoodoo</span><span class="ruby-operator">::</span><span class="ruby-constant">ActiveRecord</span><span class="ruby-operator">::</span><span class="ruby-constant">Support</span>.<span class="ruby-identifier">framework_search_and_filter_data</span>()
+  <span class="ruby-identifier">model</span>.<span class="ruby-identifier">nz_co_loyalty_hoodoo_filter_with</span> = <span class="ruby-constant">Hoodoo</span><span class="ruby-operator">::</span><span class="ruby-constant">ActiveRecord</span><span class="ruby-operator">::</span><span class="ruby-constant">Support</span>.<span class="ruby-identifier">framework_search_and_filter_data</span>()
 <span class="ruby-keyword">end</span></pre>
               </div>
             </div>

--- a/docs/rdoc/created.rid
+++ b/docs/rdoc/created.rid
@@ -1,4 +1,4 @@
-Wed, 07 Dec 2016 08:13:39 +1300
+Wed, 07 Dec 2016 09:15:26 +1300
 README.md	Wed, 12 Oct 2016 14:04:49 +1300
 lib/hoodoo.rb	Wed, 12 Oct 2016 14:04:49 +1300
 lib/hoodoo/active.rb	Wed, 12 Oct 2016 14:04:49 +1300
@@ -7,7 +7,7 @@ lib/hoodoo/active/active_record/base.rb	Wed, 12 Oct 2016 14:04:49 +1300
 lib/hoodoo/active/active_record/creator.rb	Wed, 12 Oct 2016 14:04:49 +1300
 lib/hoodoo/active/active_record/dated.rb	Wed, 12 Oct 2016 14:04:49 +1300
 lib/hoodoo/active/active_record/error_mapping.rb	Wed, 12 Oct 2016 14:04:49 +1300
-lib/hoodoo/active/active_record/finder.rb	Wed, 07 Dec 2016 08:09:03 +1300
+lib/hoodoo/active/active_record/finder.rb	Wed, 07 Dec 2016 09:11:05 +1300
 lib/hoodoo/active/active_record/manually_dated.rb	Wed, 12 Oct 2016 14:04:49 +1300
 lib/hoodoo/active/active_record/search_helper.rb	Tue, 06 Dec 2016 08:43:25 +1300
 lib/hoodoo/active/active_record/secure.rb	Wed, 12 Oct 2016 14:04:49 +1300
@@ -104,7 +104,7 @@ lib/hoodoo/services/middleware/middleware.rb	Tue, 06 Dec 2016 08:43:25 +1300
 lib/hoodoo/services/middleware/rack_monkey_patch.rb	Wed, 12 Oct 2016 14:04:49 +1300
 lib/hoodoo/services/services/context.rb	Wed, 12 Oct 2016 14:04:49 +1300
 lib/hoodoo/services/services/implementation.rb	Wed, 12 Oct 2016 14:04:49 +1300
-lib/hoodoo/services/services/interface.rb	Wed, 07 Dec 2016 08:13:34 +1300
+lib/hoodoo/services/services/interface.rb	Wed, 07 Dec 2016 08:51:43 +1300
 lib/hoodoo/services/services/permissions.rb	Wed, 12 Oct 2016 14:04:49 +1300
 lib/hoodoo/services/services/request.rb	Wed, 12 Oct 2016 14:04:49 +1300
 lib/hoodoo/services/services/response.rb	Wed, 12 Oct 2016 14:04:49 +1300
@@ -114,4 +114,4 @@ lib/hoodoo/utilities.rb	Wed, 12 Oct 2016 14:04:49 +1300
 lib/hoodoo/utilities/string_inquirer.rb	Wed, 12 Oct 2016 14:04:49 +1300
 lib/hoodoo/utilities/utilities.rb	Wed, 12 Oct 2016 14:04:49 +1300
 lib/hoodoo/utilities/uuid.rb	Wed, 12 Oct 2016 14:04:49 +1300
-lib/hoodoo/version.rb	Wed, 07 Dec 2016 08:10:15 +1300
+lib/hoodoo/version.rb	Wed, 07 Dec 2016 09:15:05 +1300

--- a/lib/hoodoo/active/active_record/finder.rb
+++ b/lib/hoodoo/active/active_record/finder.rb
@@ -65,9 +65,6 @@ module Hoodoo
         unless model == Hoodoo::ActiveRecord::Base
           model.send( :include, Hoodoo::ActiveRecord::Secure )
           instantiate( model )
-
-          model.nz_co_loyalty_hoodoo_search_with = Hoodoo::ActiveRecord::Support.framework_search_and_filter_data()
-          model.nz_co_loyalty_hoodoo_filter_with = Hoodoo::ActiveRecord::Support.framework_search_and_filter_data()
         end
 
         super( model )
@@ -85,6 +82,9 @@ module Hoodoo
       #
       def self.instantiate( model )
         model.extend( ClassMethods )
+
+        model.nz_co_loyalty_hoodoo_search_with = Hoodoo::ActiveRecord::Support.framework_search_and_filter_data()
+        model.nz_co_loyalty_hoodoo_filter_with = Hoodoo::ActiveRecord::Support.framework_search_and_filter_data()
       end
 
       # Collection of class methods that get defined on an including class via

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -12,6 +12,6 @@ module Hoodoo
   # The Hoodoo gem version. If this changes, ensure that the date in
   # "hoodoo.gemspec" is correct and run "bundle install" (or "update").
   #
-  VERSION = '1.12.1'
+  VERSION = '1.12.2'
 
 end

--- a/spec/active/active_record/finder_spec.rb
+++ b/spec/active/active_record/finder_spec.rb
@@ -86,9 +86,26 @@ describe Hoodoo::ActiveRecord::Finder do
       filter_with( search_and_filter_map )
     end
 
-    class RSpecModelFinderTestWithoutSearchOrFilter < ActiveRecord::Base
+    class RSpecModelFinderWithoutSearchOrFilterTest < ActiveRecord::Base
       include Hoodoo::ActiveRecord::Finder
 
+      self.primary_key = :id
+      self.table_name = :r_spec_model_finder_tests
+    end
+
+    class RSpecModelFinderSubclassTest < Hoodoo::ActiveRecord::Base
+      self.primary_key = :id
+      self.table_name = :r_spec_model_finder_tests
+
+      search_and_filter_map = {
+        'mapped_code' => Hoodoo::ActiveRecord::Finder::SearchHelper.cs_match( 'code' )
+      }
+
+      search_with( search_and_filter_map )
+      filter_with( search_and_filter_map )
+    end
+
+    class RSpecModelFinderSubclassWithoutSearchOrFilterTest < Hoodoo::ActiveRecord::Base
       self.primary_key = :id
       self.table_name = :r_spec_model_finder_tests
     end
@@ -131,13 +148,21 @@ describe Hoodoo::ActiveRecord::Finder do
     @c.save!
     @code = @c.code
 
-    @a_wh = RSpecModelFinderTestWithHelpers.find( @a.id )
-    @b_wh = RSpecModelFinderTestWithHelpers.find( @b.id )
-    @c_wh = RSpecModelFinderTestWithHelpers.find( @c.id )
+    @a_wh        = RSpecModelFinderTestWithHelpers.find( @a.id )
+    @b_wh        = RSpecModelFinderTestWithHelpers.find( @b.id )
+    @c_wh        = RSpecModelFinderTestWithHelpers.find( @c.id )
 
-    @a_wosf = RSpecModelFinderTestWithoutSearchOrFilter.find( @a.id )
-    @b_wosf = RSpecModelFinderTestWithoutSearchOrFilter.find( @b.id )
-    @c_wosf = RSpecModelFinderTestWithoutSearchOrFilter.find( @c.id )
+    @a_wosf      = RSpecModelFinderWithoutSearchOrFilterTest.find( @a.id )
+    @b_wosf      = RSpecModelFinderWithoutSearchOrFilterTest.find( @b.id )
+    @c_wosf      = RSpecModelFinderWithoutSearchOrFilterTest.find( @c.id )
+
+    @a_sc        = RSpecModelFinderSubclassTest.find( @a.id )
+    @b_sc        = RSpecModelFinderSubclassTest.find( @b.id )
+    @c_sc        = RSpecModelFinderSubclassTest.find( @c.id )
+
+    @a_sc_wosf   = RSpecModelFinderSubclassWithoutSearchOrFilterTest.find( @a.id )
+    @b_sc_wosf   = RSpecModelFinderSubclassWithoutSearchOrFilterTest.find( @b.id )
+    @c_sc_wosf   = RSpecModelFinderSubclassWithoutSearchOrFilterTest.find( @c.id )
 
     @list_params = Hoodoo::Services::Request::ListParameters.new
   end
@@ -790,7 +815,7 @@ describe Hoodoo::ActiveRecord::Finder do
         'created_after' => @tn - 1.month
       }
 
-      finder = RSpecModelFinderTestWithoutSearchOrFilter.list( @list_params )
+      finder = RSpecModelFinderWithoutSearchOrFilterTest.list( @list_params )
       expect( finder ).to eq( [ @c_wosf ] )
     end
 
@@ -799,8 +824,43 @@ describe Hoodoo::ActiveRecord::Finder do
         'created_before' => @tn - 1.month
       }
 
-      finder = RSpecModelFinderTestWithoutSearchOrFilter.list( @list_params )
+      finder = RSpecModelFinderWithoutSearchOrFilterTest.list( @list_params )
       expect( finder ).to eq( [ @a_wosf ] )
+    end
+  end
+
+  # ==========================================================================
+
+  context 'as a Hoodoo::ActiveRecord::Base subclass' do # (instead of explicitly including the Finder module)
+    context 'custom search' do
+      it 'on mapped_code' do
+        @list_params.search_data = {
+          'mapped_code' => @code
+        }
+
+        finder = RSpecModelFinderSubclassTest.list( @list_params )
+        expect( finder ).to eq( [ @c_sc ] )
+      end
+    end
+
+    context 'pure framework search' do
+      it 'on created_after' do
+        @list_params.search_data = {
+          'created_after' => @tn - 1.month
+        }
+
+        finder = RSpecModelFinderSubclassWithoutSearchOrFilterTest.list( @list_params )
+        expect( finder ).to eq( [ @c_sc_wosf ] )
+      end
+
+      it 'on created_before' do
+        @list_params.search_data = {
+          'created_before' => @tn - 1.month
+        }
+
+        finder = RSpecModelFinderSubclassWithoutSearchOrFilterTest.list( @list_params )
+        expect( finder ).to eq( [ @a_sc_wosf ] )
+      end
     end
   end
 
@@ -1017,7 +1077,7 @@ describe Hoodoo::ActiveRecord::Finder do
         'created_after' => @tn - 1.month
       }
 
-      finder = RSpecModelFinderTestWithoutSearchOrFilter.list( @list_params )
+      finder = RSpecModelFinderWithoutSearchOrFilterTest.list( @list_params )
       expect( finder ).to eq( [ @b_wosf, @a_wosf ] )
     end
 
@@ -1026,8 +1086,43 @@ describe Hoodoo::ActiveRecord::Finder do
         'created_before' => @tn - 1.month
       }
 
-      finder = RSpecModelFinderTestWithoutSearchOrFilter.list( @list_params )
+      finder = RSpecModelFinderWithoutSearchOrFilterTest.list( @list_params )
       expect( finder ).to eq( [ @c_wosf, @b_wosf ] )
+    end
+  end
+
+  # ==========================================================================
+
+  context 'as a Hoodoo::ActiveRecord::Base subclass' do # (instead of explicitly including the Finder module)
+    context 'custom filter' do
+      it 'on mapped_code' do
+        @list_params.filter_data = {
+          'mapped_code' => @code
+        }
+
+        finder = RSpecModelFinderSubclassTest.list( @list_params )
+        expect( finder ).to eq( [ @b_sc, @a_sc ] )
+      end
+    end
+
+    context 'pure framework filter' do
+      it 'on created_after' do
+        @list_params.filter_data = {
+          'created_after' => @tn - 1.month
+        }
+
+        finder = RSpecModelFinderSubclassWithoutSearchOrFilterTest.list( @list_params )
+        expect( finder ).to eq( [ @b_sc_wosf, @a_sc_wosf ] )
+      end
+
+      it 'on created_before' do
+        @list_params.filter_data = {
+          'created_before' => @tn - 1.month
+        }
+
+        finder = RSpecModelFinderSubclassWithoutSearchOrFilterTest.list( @list_params )
+        expect( finder ).to eq( [ @c_sc_wosf, @b_sc_wosf ] )
+      end
     end
   end
 


### PR DESCRIPTION
Delayed by GitHub outage - final fix, which is more serious as it caused problems with subclasses of the Hoodoo AR Base module rather than direct inclusions. Again, explicit test coverage reproducing the fault was added prior to fix. 1.12.1 was yanked from RubyGems to avoid client breakage.