### PR TITLE
Add support for setting the HTTP open timeout value in Hoodoo::Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 1.17.0 (2017-08-91)
+## 1.17.1 (2017-08-16)
+
+* Can set the [`http_open_timeout`](https://cdn.rawgit.com/LoyaltyNZ/hoodoo/master/docs/rdoc/classes/Hoodoo/Services/Discovery/ByConvention.html) for `Hoodoo::Client` connections. The [default timeout](https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html) for opening a connection is 60 seconds, which may be too long for some callers
+
+## 1.17.0 (2017-08-01)
 
 * Higher precision `created_at` (and for sessions, `expires_at`) default time rendering. For some use cases, to-one-second accuracy was insufficient. New method [`Hoodoo::Utilities::standard_datetime`](https://cdn.rawgit.com/LoyaltyNZ/hoodoo/master/docs/rdoc/classes/Hoodoo/Utilities.html#method-c-standard_datetime) is used for this.
 

--- a/lib/hoodoo/client/endpoint/endpoints/http.rb
+++ b/lib/hoodoo/client/endpoint/endpoints/http.rb
@@ -33,12 +33,13 @@ module Hoodoo
               raise "Hoodoo::Client::Endpoint::HTTP must be configured with a Hoodoo::Services::Discovery::ForHTTP instance - got '#{ @discovery_result.class.name }'"
             end
 
-            @description                  = Hoodoo::Client::Endpoint::HTTPBased::DescriptionOfRequest.new
-            @description.discovery_result = @discovery_result
-            @description.endpoint_uri     = @discovery_result.endpoint_uri
-            @description.proxy_uri        = @discovery_result.proxy_uri
-            @description.ca_file          = @discovery_result.ca_file
-            @description.http_timeout     = @discovery_result.http_timeout
+            @description                   = Hoodoo::Client::Endpoint::HTTPBased::DescriptionOfRequest.new
+            @description.discovery_result  = @discovery_result
+            @description.endpoint_uri      = @discovery_result.endpoint_uri
+            @description.proxy_uri         = @discovery_result.proxy_uri
+            @description.ca_file           = @discovery_result.ca_file
+            @description.http_timeout      = @discovery_result.http_timeout
+            @description.http_open_timeout = @discovery_result.http_open_timeout
           end
 
         public
@@ -115,10 +116,11 @@ module Hoodoo
 
             data = get_data_for_request( description_of_request )
 
-            action       = description_of_request.action
-            proxy        = description_of_request.proxy_uri
-            ca_file      = description_of_request.ca_file
-            http_timeout = description_of_request.http_timeout
+            action            = description_of_request.action
+            proxy             = description_of_request.proxy_uri
+            ca_file           = description_of_request.ca_file
+            http_timeout      = description_of_request.http_timeout
+            http_open_timeout = description_of_request.http_open_timeout
 
             proxy_host = :ENV
             proxy_port = proxy_user = proxy_pass = nil
@@ -157,6 +159,7 @@ module Hoodoo
             end
 
             http.read_timeout = http_timeout unless http_timeout.nil?
+            http.open_timeout = http_open_timeout unless http_open_timeout.nil?
 
             request_class = {
               :create => Net::HTTP::Post,
@@ -174,6 +177,7 @@ module Hoodoo
             description_of_response.http_headers = {}
 
             begin
+
               http_response = http.request( request )
 
               description_of_response.http_status_code = http_response.code.to_i
@@ -184,7 +188,7 @@ module Hoodoo
               description_of_response.http_status_code = 404
               description_of_response.raw_body_data    = ''
 
-            rescue Net::ReadTimeout => e
+            rescue Net::ReadTimeout, Net::OpenTimeout => e
               description_of_response.http_status_code = 408
               description_of_response.raw_body_data    = ''
 

--- a/lib/hoodoo/client/endpoint/endpoints/http_based.rb
+++ b/lib/hoodoo/client/endpoint/endpoints/http_based.rb
@@ -76,6 +76,12 @@ module Hoodoo
             #
             attr_accessor :http_timeout
 
+            # Optional Float indicating the Net::HTTP open timeout value.
+            # This operates at the HTTP transport level and is independent
+            # of any timeouts set within the API providing server.
+            #
+            attr_accessor :http_open_timeout
+
             # Optional Hash of query data.
             #
             attr_accessor :query_hash

--- a/lib/hoodoo/services/discovery/discoverers/by_convention.rb
+++ b/lib/hoodoo/services/discovery/discoverers/by_convention.rb
@@ -36,42 +36,47 @@ module Hoodoo
             #
             # Options are:
             #
-            # +base_uri+::     A String giving the base URI at which resource
-            #                  endpoint implementations can be found. The
-            #                  protocol (HTTP or HTTPS), host and port are of
-            #                  interest. The path will be overwritten with
-            #                  by-convention values for individual resources.
+            # +base_uri+::          A String giving the base URI at which resource
+            #                       endpoint implementations can be found. The
+            #                       protocol (HTTP or HTTPS), host and port are of
+            #                       interest. The path will be overwritten with
+            #                       by-convention values for individual resources.
             #
-            # +proxy_uri+::    An optional full URI of an HTTP proxy to use if
-            #                  the base URI commands use of HTTP or HTTPS. Ruby
-            #                  will itself read <tt>ENV['HTTP_PROXY']</tt> if
-            #                  set; this option will _override_ that variable.
-            #                  Set as a String, as with +base_uri+.
+            # +proxy_uri+::         An optional full URI of an HTTP proxy to use if
+            #                       the base URI commands use of HTTP or HTTPS. Ruby
+            #                       will itself read <tt>ENV['HTTP_PROXY']</tt> if
+            #                       set; this option will _override_ that variable.
+            #                       Set as a String, as with +base_uri+.
             #
-            # +ca_file+::      An optional String indicating a relative or
-            #                  absolute file path to the location of a +.pem+
-            #                  format Certificate Authority file (trust store),
-            #                  which may include multliple certificates. The
-            #                  certificates in the file will be used by
-            #                  Net::HTTP to validate the SSL ceritificate
-            #                  chain presented by remote servers, when calling
-            #                  endpoints over HTTPS with Hoodoo::Client.
+            # +ca_file+::           An optional String indicating a relative or
+            #                       absolute file path to the location of a +.pem+
+            #                       format Certificate Authority file (trust store),
+            #                       which may include multliple certificates. The
+            #                       certificates in the file will be used by
+            #                       Net::HTTP to validate the SSL ceritificate
+            #                       chain presented by remote servers, when calling
+            #                       endpoints over HTTPS with Hoodoo::Client.
             #
-            #                  Default +nil+ value should be used in nearly all
-            #                  cases and uses Ruby OpenSSL defaults which are
-            #                  generally Operating System provided.
+            #                       Default +nil+ value should be used in nearly all
+            #                       cases and uses Ruby OpenSSL defaults which are
+            #                       generally Operating System provided.
             #
-            # +http_timeout+:: Optional Float indicating the Net::HTTP read
-            #                  timeout value. This operates at the HTTP
-            #                  transport level and is independent of any
-            #                  timeouts set within the API providing server.
+            # +http_timeout+::      Optional Float indicating the Net::HTTP <b>read</b>
+            #                       timeout value. This operates at the HTTP
+            #                       transport level and is independent of any
+            #                       timeouts set within the API providing server.
             #
-            # +routing+::      An optional parameter which gives custom routing
-            #                  for exception cases where the by-convention map
-            #                  doesn't work. This is usually because there is a
-            #                  resource singleton which lives logically at a
-            #                  singular named route rather than plural route,
-            #                  e.g. "/v1/health" rather than "/v1/healths".
+            # +http_open_timeout+:: Optional Float indicating the Net::HTTP <b>open</b>
+            #                       timeout value. This operates at the HTTP
+            #                       transport level and is independent of any
+            #                       timeouts set within the API providing server.
+            #
+            # +routing+::           An optional parameter which gives custom routing
+            #                       for exception cases where the by-convention map
+            #                       doesn't work. This is usually because there is a
+            #                       resource singleton which lives logically at a
+            #                       singular named route rather than plural route,
+            #                       e.g. "/v1/health" rather than "/v1/healths".
             #
             # The +routing+ parameter is a Hash of Resource names _as_
             # _Symbols_, then values which are Hash of API Version _as_
@@ -99,11 +104,12 @@ module Hoodoo
             # actually Hoodoo itself but implemented in a compatible fashion.
             #
             def configure_with( options )
-              @base_uri     = URI.parse( options[ :base_uri  ] )
-              @proxy_uri    = URI.parse( options[ :proxy_uri ] ) unless options[ :proxy_uri ].nil?
-              @ca_file      = options[ :ca_file ]
-              @http_timeout = options[ :http_timeout ]
-              @routing      = options[ :routing ] || {}
+              @base_uri          = URI.parse( options[ :base_uri  ] )
+              @proxy_uri         = URI.parse( options[ :proxy_uri ] ) unless options[ :proxy_uri ].nil?
+              @ca_file           = options[ :ca_file ]
+              @http_timeout      = options[ :http_timeout ]
+              @http_open_timeout = options[ :http_open_timeout ]
+              @routing           = options[ :routing ] || {}
             end
 
             # Announce the location of an instance. This is really a no-op
@@ -154,12 +160,13 @@ module Hoodoo
               endpoint_uri.path = path
 
               return Hoodoo::Services::Discovery::ForHTTP.new(
-                resource:     resource,
-                version:      version,
-                endpoint_uri: endpoint_uri,
-                proxy_uri:    @proxy_uri,
-                ca_file:      @ca_file,
-                http_timeout: @http_timeout
+                resource:          resource,
+                version:           version,
+                endpoint_uri:      endpoint_uri,
+                proxy_uri:         @proxy_uri,
+                ca_file:           @ca_file,
+                http_timeout:      @http_timeout,
+                http_open_timeout: @http_open_timeout
               )
             end
 

--- a/lib/hoodoo/services/discovery/results/for_http.rb
+++ b/lib/hoodoo/services/discovery/results/for_http.rb
@@ -56,28 +56,37 @@ module Hoodoo
         #
         attr_accessor :http_timeout
 
+        # Optional Float indicating the Net::HTTP open timeout value.
+        # This operates at the HTTP transport level and is independent
+        # of any timeouts set within the API providing server.
+        #
+        attr_accessor :http_open_timeout
+
         # Create an instance with named parameters as follows:
         #
-        # +resource+::     See #resource.
-        # +version+::      See #version.
-        # +endpoint_uri+:: See #endpoint_uri.
-        # +proxy_uri+::    See #proxy_uri. Optional.
-        # +ca_file+::      See #ca_file. Optional.
-        # +http_timeout+:: See #http_timeout. Optional.
+        # +resource+::          See #resource.
+        # +version+::           See #version.
+        # +endpoint_uri+::      See #endpoint_uri.
+        # +proxy_uri+::         See #proxy_uri. Optional.
+        # +ca_file+::           See #ca_file. Optional.
+        # +http_timeout+::      See #http_timeout. Optional.
+        # +http_open_timeout+:: See #http_open_timeout. Optional.
         #
         def initialize( resource:,
                         version:,
                         endpoint_uri:,
-                        proxy_uri:    nil,
-                        ca_file:      nil,
-                        http_timeout: nil )
+                        proxy_uri:         nil,
+                        ca_file:           nil,
+                        http_timeout:      nil,
+                        http_open_timeout: nil )
 
-          self.resource     = resource.to_sym
-          self.version      = version.to_i
-          self.endpoint_uri = endpoint_uri
-          self.proxy_uri    = proxy_uri
-          self.ca_file      = ca_file
-          self.http_timeout = http_timeout
+          self.resource          = resource.to_sym
+          self.version           = version.to_i
+          self.endpoint_uri      = endpoint_uri
+          self.proxy_uri         = proxy_uri
+          self.ca_file           = ca_file
+          self.http_timeout      = http_timeout
+          self.http_open_timeout = http_open_timeout
         end
       end
     end

--- a/spec/client/client_spec.rb
+++ b/spec/client/client_spec.rb
@@ -484,6 +484,31 @@ describe Hoodoo::Client do
       end
     end
 
+    context 'and with a custom HTTP open timeout' do
+      before :each do
+        base_uri   = "http://localhost:#{ @port }"
+        discoverer = Hoodoo::Services::Discovery::ByConvention.new(
+          base_uri:          base_uri,
+          http_open_timeout: 0.0000001
+        )
+
+        set_vars_for(
+          base_uri:     base_uri,
+          auto_session: false,
+          session_id:   @old_test_session.session_id,
+          discoverer:   discoverer
+        )
+      end
+
+      it 'times out elegantly' do
+        mock_ident = Hoodoo::UUID.generate()
+        result     = @endpoint.show( mock_ident )
+
+        expect( result.platform_errors.has_errors? ).to eq( true )
+        expect( result.platform_errors.errors[ 0 ][ 'code' ] ).to eq( 'platform.timeout' )
+      end
+    end
+
     context 'and with custom routing' do
       it 'obeys the routes' do
         base_uri   = "http://localhost:#{ @port }"

--- a/spec/services/discovery/results/for_http_spec.rb
+++ b/spec/services/discovery/results/for_http_spec.rb
@@ -24,14 +24,16 @@ describe Hoodoo::Services::Discovery::ForHTTP do
       endpoint_uri: endpoint_uri(),
       proxy_uri: proxy_uri(),
       ca_file: 'foo.pem',
-      http_timeout: 0.25
+      http_timeout: 0.25,
+      http_open_timeout: 2.5
     )
 
-    expect( r.resource     ).to eq( :Bar ) # Also Symbol
-    expect( r.version      ).to eq( 2 )
-    expect( r.endpoint_uri ).to eq( endpoint_uri() )
-    expect( r.proxy_uri    ).to eq( proxy_uri() )
-    expect( r.ca_file      ).to eq( 'foo.pem' )
-    expect( r.http_timeout ).to eq( 0.25 )
+    expect( r.resource          ).to eq( :Bar ) # Also Symbol
+    expect( r.version           ).to eq( 2 )
+    expect( r.endpoint_uri      ).to eq( endpoint_uri() )
+    expect( r.proxy_uri         ).to eq( proxy_uri() )
+    expect( r.ca_file           ).to eq( 'foo.pem' )
+    expect( r.http_timeout      ).to eq( 0.25 )
+    expect( r.http_open_timeout ).to eq( 2.5 )
   end
 end


### PR DESCRIPTION
Provide the ability to set an HTTP open timeout value, thus overriding the default value 60 seconds provided by Net:HTTP.
