### PR TITLE
Various fixes revealed by "bare metal" service creation

### DIFF
--- a/lib/hoodoo/services/discovery/discoverers/by_drb/by_drb.rb
+++ b/lib/hoodoo/services/discovery/discoverers/by_drb/by_drb.rb
@@ -90,7 +90,7 @@ module Hoodoo
             # subsequent runs do not - yet it stays the same, so it works out
             # OK there.
             #
-            unless discover_remote( resource, version ) || endpoint_uri_string.nil?
+            unless endpoint_uri_string.nil? || discover_remote( resource, version )
               drb_service().add( resource, version, endpoint_uri_string )
             end
 

--- a/lib/hoodoo/services/discovery/discoverers/by_drb/by_drb.rb
+++ b/lib/hoodoo/services/discovery/discoverers/by_drb/by_drb.rb
@@ -63,7 +63,7 @@ module Hoodoo
           # +version+::  Passed to #discover_remote.
           # +options+::  Options hash as described below.
           #
-          # Options keys are currently all required:
+          # Options keys are:
           #
           # +host+:: Host name as a string for location of service endpoint,
           #          over HTTP (usually, local development is assumed).
@@ -72,20 +72,25 @@ module Hoodoo
           #
           # +path+:: Path on the above host and port of service endpoint.
           #
+          # If any are missing or +nil+, remote announcement is aborted and
+          # the return value is correspondingly +nil+.
+          #
           def announce_remote( resource, version, options = {} )
 
             host = options[ :host ]
             port = options[ :port ]
             path = options[ :path ]
 
-            endpoint_uri_string = "http://#{ host }:#{ port }#{ path }"
+            endpoint_uri_string = unless host.nil? || port.nil? || path.nil?
+              "http://#{ host }:#{ port }#{ path }"
+            end
 
-            # Announce our local services if we managed to find the host and port,
-            # but no point otherwise; the values could be anything. In a 'guard'
-            # based environment, first-run determines host and port but subsequent
-            # runs do not - yet it stays the same, so it works out OK there.
+            # Announce our local services only if we have an endpoint URI. In a
+            # 'guard' based environment, first-run determines host and port but
+            # subsequent runs do not - yet it stays the same, so it works out
+            # OK there.
             #
-            unless host.nil? || port.nil? || discover_remote( resource, version )
+            unless discover_remote( resource, version ) || endpoint_uri_string.nil?
               drb_service().add( resource, version, endpoint_uri_string )
             end
 
@@ -157,7 +162,7 @@ module Hoodoo
             rescue DRb::DRbConnError
               if start_on_localhost_if_not_already_running
                 script_path = File.join( File.dirname( __FILE__ ), 'drb_server_start.rb' )
-                command     = "bundle exec ruby '#{ script_path }'"
+                command     = "#{ defined?( Bundler ) ? 'bundle exec ' : '' }ruby '#{ script_path }'"
                 command    << " --port #{ @drb_port }" unless @drb_port.nil? || @drb_port.empty?
 
                 Process.detach( spawn( command ) )

--- a/lib/hoodoo/services/middleware/middleware.rb
+++ b/lib/hoodoo/services/middleware/middleware.rb
@@ -12,6 +12,7 @@
 ########################################################################
 
 require 'set'
+require 'cgi'
 require 'uri'
 require 'json'
 require 'benchmark'
@@ -426,7 +427,7 @@ module Hoodoo; module Services
     # Record internally the HTTP host and port during local development via
     # e.g +rackup+ or testing with rspec. This is usually not called directly
     # except via the Rack startup monkey patch code in
-    # +rack_monkey_patch.rb+.
+    # +instrumented_rack.rb+.
     #
     # Options hash +:Host+ and +:Port+ entries are recorded.
     #
@@ -1587,8 +1588,8 @@ module Hoodoo; module Services
           end
         end
 
-        host = @@recorded_host if host.nil? && defined?( @@recorded_host )
-        port = @@recorded_port if port.nil? && defined?( @@recorded_port )
+        host ||= @@recorded_host if defined?( @@recorded_host )
+        port ||= @@recorded_port if defined?( @@recorded_port )
 
         # Under test, ensure a simulation of an available host and port is
         # always available for discovery-related tests.
@@ -1598,23 +1599,23 @@ module Hoodoo; module Services
           port ||= '9292'
         end
 
-        # Announce the resource endpoints unless we are still missing a host
-        # or port. Implication is 'racksh'.
+        # Announce the resource endpoints. We might not be able to annouce
+        # the remote availability of this endpoint if the host/port are not
+        # determined; but that might just be because we are running under
+        # "racksh" and we wouldn't want to announce remotely anyway.
 
-        unless host.nil? || port.nil?
-          services.each do | service |
-            interface = service.interface_class
+        services.each do | service |
+          interface = service.interface_class
 
-            @discoverer.announce(
-              interface.resource,
-              interface.version,
-              {
-                :host => host,
-                :port => port,
-                :path => service.base_path
-              }
-            )
-          end
+          @discoverer.announce(
+            interface.resource,
+            interface.version,
+            {
+              :host => host,
+              :port => port,
+              :path => service.base_path
+            }
+          )
         end
       end
     end
@@ -1762,7 +1763,7 @@ module Hoodoo; module Services
       # We try the custom routing path first, then the de facto path, then
       # give up if neither match.
 
-      uri_path = CGI.unescape( interaction.rack_request.path() )
+      uri_path = ::CGI.unescape( interaction.rack_request.path() )
 
       selected_path_data = nil
       selected_services  = @@services.select do | service_data |

--- a/lib/hoodoo/services/middleware/middleware.rb
+++ b/lib/hoodoo/services/middleware/middleware.rb
@@ -427,7 +427,7 @@ module Hoodoo; module Services
     # Record internally the HTTP host and port during local development via
     # e.g +rackup+ or testing with rspec. This is usually not called directly
     # except via the Rack startup monkey patch code in
-    # +instrumented_rack.rb+.
+    # +rack_monkey_patch.rb+.
     #
     # Options hash +:Host+ and +:Port+ entries are recorded.
     #

--- a/spec/services/discovery/discoverers/by_drb/by_drb_spec.rb
+++ b/spec/services/discovery/discoverers/by_drb/by_drb_spec.rb
@@ -88,6 +88,14 @@ describe Hoodoo::Services::Discovery::ByDRb do
       discoverer.announce( :Foo, 1, options )
       expect( discoverer.is_local?( :Foo, 1 ) ).to eq( true )
 
+      # This is important as it has a side effect of starting the DRb
+      # server which may not even be running yet since there have been
+      # no remote announcements. That'd cause the tests below here to
+      # fail since the discoverer is configured there to assume a
+      # running DRb process.
+      #
+      expect( discoverer.send( :discover_remote, :Foo, 1 ) ).to be_nil
+
       # Now enquire in a new discoverer, which can only get its data
       # from the DRb service, as if this were a second service.
       #
@@ -99,6 +107,8 @@ describe Hoodoo::Services::Discovery::ByDRb do
       expect( discoverer.discover( :Foo, 1 ) ).to be_nil
 
     end
+
+    shut_down_drb_service_on( port )
   end
 
   it 'complains if it cannot contact an existing DRb server' do

--- a/spec/transient_store/transient_store/mocks/redis_spec.rb
+++ b/spec/transient_store/transient_store/mocks/redis_spec.rb
@@ -25,7 +25,7 @@ describe Hoodoo::TransientStore::Mocks::Redis do
     end
   end
 
-  context 'mimic approcimated old behaviour of its Memcached counterpart by' do
+  context 'mimic approximated old behaviour of its Memcached counterpart by' do
     it 'using the mock client in test mode if there is an empty host' do
       expect_any_instance_of( Hoodoo::TransientStore::Mocks::Redis ).to receive( :initialize ).once.and_call_original()
 
@@ -47,17 +47,19 @@ describe Hoodoo::TransientStore::Mocks::Redis do
     it 'using a real client in test mode if there is a defined host' do
       expect_any_instance_of( ::Redis ).to receive( :initialize ).once.and_call_original()
 
-      # Silence 'Errno::ECONNREFUSED' warnings if Memcached is not actually
-      # running at the given URI. That's fine; it's the initializer test
-      # above which is important.
+      # If Redis is missing, Hoodoo raises an exception. Allow that in case no
+      # real Redis server is present, but don't allow other exceptions.
       #
-      spec_helper_silence_stream( $stdout ) do
-        spec_helper_silence_stream( $stderr ) do
+      begin
+        spec_helper_silence_stream( $stdout ) do
           Hoodoo::TransientStore::Redis.new(
             storage_host_uri: 'redis://localhost:6379',
             namespace:        'test_namespace_'
           )
         end
+      rescue => e
+        expect( e         ).to be_a( RuntimeError )
+        expect( e.message ).to include( "Hoodoo::TransientStore::Redis: Cannot connect to Redis at 'redis://localhost:6379': " )
       end
     end
   end

--- a/spec/transient_store/transient_store/mocks/redis_spec.rb
+++ b/spec/transient_store/transient_store/mocks/redis_spec.rb
@@ -25,7 +25,7 @@ describe Hoodoo::TransientStore::Mocks::Redis do
     end
   end
 
-  context 'mimic approximated old behaviour of its Memcached counterpart by' do
+  context 'approximate old behaviour by' do
     it 'using the mock client in test mode if there is an empty host' do
       expect_any_instance_of( Hoodoo::TransientStore::Mocks::Redis ).to receive( :initialize ).once.and_call_original()
 


### PR DESCRIPTION
When trying to create a service like the bare metal example on the front page of http://hoodoo.cloud, but with two resources inside the service unit where one called another on should-be-local inter-resource call, a few things didn't quite work properly:

* As usual it tried to run up with the ByDRb discoverer.
* DRb server tried to launch but we weren't using `bundler` so it failed.
* Working around by using a `Gemfile` and Bundler yielded a crash in middleware as `CGI` wasn't recognised as a constant.
* Manually `require`-ing `cgi` led to a cannot-find-resource error because the lack of a discovered host/port meant no service announcements were made, so even the local resources were not known about internally.

Resolved through the following changes:

* Have by-DRb discoverer try to launch the server with or without bundler according to whether it thinks the service was launched that way (via somewhat weak "is constant `Bundler` defined?" check).
* Ensure CGI module is present and address top level namespace explicitly.
* Have by-DRb discoverer survive/allow missing hosts/ports/paths.
* Always announce services whether or not host/port are known, for local resource discovery / inter-resource local call functions to work on a bare metal system.
