### PR TITLE
Airbrake 6->7 and Airbrake bug work-around

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,8 +27,10 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    airbrake (6.3.0)
-      airbrake-ruby (~> 2.4)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    airbrake (7.1.0)
+      airbrake-ruby (~> 2.5)
     airbrake-ruby (2.5.1)
     alchemy-flux (1.1.0)
       amqp (~> 1.5)
@@ -42,11 +44,14 @@ GEM
     arel (8.0.0)
     byebug (9.1.0)
     concurrent-ruby (1.0.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     dalli (2.7.6)
     database_cleaner (1.6.2)
     diff-lcs (1.3)
     docile (1.1.5)
     eventmachine (1.2.5)
+    hashdiff (0.3.7)
     httparty (0.15.6)
       multi_xml (>= 0.5.2)
     i18n (0.9.1)
@@ -56,11 +61,13 @@ GEM
     minitest (5.10.3)
     multi_xml (0.6.0)
     pg (0.21.0)
+    public_suffix (3.0.0)
     rack (2.0.3)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
     rake (12.2.1)
-    raygun4ruby (1.5.0)
+    raygun4ruby (2.6.0)
+      concurrent-ruby
       httparty (> 0.13.7)
       json
       rack
@@ -79,6 +86,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
+    safe_yaml (1.0.4)
     simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -91,6 +99,10 @@ GEM
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uuidtools (2.1.5)
+    webmock (3.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -98,7 +110,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 5.1)
   activesupport (~> 5.1)
-  airbrake (~> 6.2)
+  airbrake (~> 7.1)
   alchemy-flux (= 1.1)
   byebug (~> 9.0)
   database_cleaner (~> 1.6)
@@ -108,7 +120,7 @@ DEPENDENCIES
   rack (~> 2.0)
   rack-test (~> 0.6)
   rake (~> 12.0)
-  raygun4ruby (~> 1.1)
+  raygun4ruby (~> 2.6)
   rdoc (~> 5.1)
   redis (~> 3.3)
   rspec (~> 3.5)
@@ -116,6 +128,7 @@ DEPENDENCIES
   sdoc!
   simplecov-rcov (~> 0.2)
   timecop (~> 0.8)
+  webmock (~> 3.1)
 
 BUNDLED WITH
    1.16.0

--- a/hoodoo.gemspec
+++ b/hoodoo.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do | s |
   s.test_files  = Dir.glob( 'spec/**/*.rb' )
   s.homepage    = 'https://loyaltynz.github.io/hoodoo/'
 
-  s.required_ruby_version = '>= 2.2.7'
+  s.required_ruby_version = '>= 2.2.8'
 
   s.add_runtime_dependency     'dalli',            '~> 2.7' # Memcached client
 
@@ -25,18 +25,18 @@ Gem::Specification.new do | s |
   s.add_development_dependency 'rake',             '~> 12.0'
   s.add_development_dependency 'simplecov-rcov',   '~> 0.2'
 
-  # TODO: v5 (SDoc dependency issue)
   s.add_development_dependency 'rdoc',             '~> 5.1' # See also 'sdoc' in Gemfile
   s.add_development_dependency 'rack-test',        '~> 0.6'
   s.add_development_dependency 'rspec',            '~> 3.5'
   s.add_development_dependency 'rspec-mocks',      '~> 3.5'
+  s.add_development_dependency 'webmock',          '~> 3.1'
   s.add_development_dependency 'activerecord',     '~> 5.1'
   s.add_development_dependency 'activesupport',    '~> 5.1'
   s.add_development_dependency 'database_cleaner', '~> 1.6'
   s.add_development_dependency 'pg',               '~> 0.21'
   s.add_development_dependency 'byebug',           '~> 9.0'
   s.add_development_dependency 'timecop',          '~> 0.8'
-  s.add_development_dependency 'raygun4ruby',      '~> 1.1' # raygun.io
-  s.add_development_dependency 'airbrake',         '~> 6.2' # airbrake.io
+  s.add_development_dependency 'raygun4ruby',      '~> 2.6' # raygun.io
+  s.add_development_dependency 'airbrake',         '~> 7.1' # airbrake.io
   s.add_development_dependency 'le',               '~> 2.7' # logentries.com
 end

--- a/lib/hoodoo/services/middleware/exception_reporting/reporters/airbrake_reporter.rb
+++ b/lib/hoodoo/services/middleware/exception_reporting/reporters/airbrake_reporter.rb
@@ -57,6 +57,8 @@ module Hoodoo; module Services
         def report( e, env )
           opts = { :backtrace => Kernel.caller() }
           opts[ :rack_env ] = env unless env.nil?
+          e    = sanitize_object(e)
+          opts = sanitize_object(opts)
 
           # Since an ExceptionReporter is already a "slow communicatory",
           # Hoodoo is using threads for behaviour; we don't need the async
@@ -81,8 +83,36 @@ module Hoodoo; module Services
             :environment_name => Hoodoo::Services::Middleware.environment,
             :session          => user_data_for( context ) || 'unknown'
           }
+          e    = sanitize_object(e)
+          opts = sanitize_object(opts)
 
           Airbrake.notify_sync( e, opts )
+        end
+
+        private
+
+        # Recursive sanitisation method for deeply nested hash objects, returning
+        # the same object in a non frozen state.
+        #
+        # Why do I exist?
+        #
+        # Due to an airbrake-ruby issue where client arguments can be mutated when within a hash,
+        # a recursive sanitisation process must therefore take place before our inputs are sent
+        # to Airbrake, ensuring no frozen hash objects are present.
+        #
+        # https://github.com/airbrake/airbrake-ruby/issues/281
+        #
+        def sanitize_object( object )
+          object = ( object.dup rescue object ) if object.frozen?
+          return object unless object.is_a?( Hash )
+
+          sanitize_hash( object )
+        end
+
+        def sanitize_hash( object )
+          object.each do | key, value |
+            object[key] = sanitize_object( value )
+          end
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,16 @@ end
 
 require 'byebug'
 
+# Stubbing Net::HTTP with WebMock - disabled by default; only enable for
+# tests where you need it, as real Net::HTTP connections are used in many
+# other tests and must not be mocked.
+#
+# https://github.com/bblimke/webmock
+
+require 'webmock/rspec'
+
+WebMock.disable!
+
 # The ActiveRecord extensions need testing in the context of a database. I
 # did consider NullDB - https://github.com/nulldb/nulldb - but this was too
 # far from 'the real thing' for my liking. Instead, we use SQLite in memory


### PR DESCRIPTION
Airbrake (at least under Ruby 2.4.2) can attempt to modify a frozen Hash. It also attempts to set the backtrace in exceptions under some circumstances, again breaking if they're frozen. Test coverage added as proof.

Drive-by bump of Raygun gem to V2, which has no relevant breaking changes in its change log.