### PR TITLE
Update readme link for gh-pages branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This is a collection of pages all providing various guides to Hoodoo, in the manner of [Rails Guides](http://guides.rubyonrails.org). The site is automatically published at [http://pond.github.io/hoodoo/](https://pond.github.io/hoodoo/) whenever the `gh-pages` branch receives a commit.
+This is a collection of pages all providing various guides to Hoodoo, in the manner of [Rails Guides](http://guides.rubyonrails.org). The site is automatically published at [http://loyaltynz.github.io/hoodoo/](https://loyaltynz.github.io/hoodoo/) whenever the `gh-pages` branch receives a commit.
 
 ## Jekyll
 


### PR DESCRIPTION
Update link from pond’s GH pages to loyaltynz. Most likely a left-over from hoodoo being open-sourced.