### PR TITLE
Fix subtle edge case with enumerate_all and :offset-vs-'offset'

### DIFF
--- a/lib/hoodoo/client/endpoint/endpoint.rb
+++ b/lib/hoodoo/client/endpoint/endpoint.rb
@@ -329,17 +329,16 @@ module Hoodoo
         # value set.
         #
         def inject_enumeration_state( augmented_array, query_hash )
+          endpoint   = self
+          query_hash = Hoodoo::Utilities.stringify( query_hash || {} )
+          batch_size = [ 1, augmented_array.size ].max
 
-          endpoint                       = self
-          query_hash                     = query_hash.nil? ? {} : query_hash.dup
-          batch_size                     = [ 1, augmented_array.size ].max
           augmented_array.next_page_proc = Proc.new do
             query_hash[ 'offset' ] = ( query_hash[ 'offset' ] || 0 ) + batch_size
             endpoint.list( query_hash )
           end
 
           return augmented_array
-
         end
 
       public


### PR DESCRIPTION
Query strings providing things like offset or limit parameters for lists are processed within Hoodoo from URIs and into hashes, thus being expressed with String keys generally. Likewise, inter-resource calls work in that domain. Hoodoo::Client however, at the top level, is often called with Symbols. At the interface between the caller-facing layer and the internal implementation, these are "stringified".

The mixin providing `enumerate_all` functionality expected String keys when working with `offset` in a query hash and would produce odd results if a Symbol was used. So, instead of doing a `dup` on the given query hash, it is Stringified instead, producing a duplicate as a side effect. This solves both problems.

Test coverage is included. The strange-looking section names arise because of the way that the RSpec DSL leads to test output with `-f d` style output semantics, in particular with `behaves like` being added automatically for `it_behaves_like` calls.

```
Hoodoo::Client
  happy path behaviour
    with different "offset" values
      behaves like enumerator which
        obeys offsets via :offset
      behaves like enumerator which
        obeys offsets via "offset"
```