### PR TITLE
Support `hash` as a valid property type for keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hoodoo v2.x
 
+## 2.12.2 (2019-07-11)
+
+* Support `hash` as a valid property type for keys.
+
 ## 2.12.1 (2019-02-22)
 
 * Disallows calls to `show` with `nil` identifiers. Previously these got interpreted as `list` calls; now they return `404 Not Found`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    hoodoo (2.12.1)
+    hoodoo (2.12.2)
       dalli (~> 2.7)
       rack
 
@@ -52,7 +52,7 @@ GEM
     concurrent-ruby (1.1.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    dalli (2.7.9)
+    dalli (2.7.10)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
     docile (1.3.1)

--- a/lib/hoodoo/presenters/base_dsl.rb
+++ b/lib/hoodoo/presenters/base_dsl.rb
@@ -747,6 +747,10 @@ module Hoodoo
       #   Hoodoo::Presenters::Text
       # [:uuid]
       #   Hoodoo::Presenters::UUID
+      # [:hash]
+      #   Hoodoo::Presenters::Hash
+      # [:object]
+      #   Hoodoo::Presenters::Object
       #
       def type_option_to_class( type )
         case type
@@ -776,6 +780,10 @@ module Hoodoo
             Hoodoo::Presenters::Text
           when :uuid
             Hoodoo::Presenters::UUID
+          when :object
+            Hoodoo::Presenters::Object
+          when :hash
+            Hoodoo::Presenters::Hash
           else
             raise "Unsupported 'type' option value of '#{ type }' in Hoodoo::Presenters::BaseDSL"
         end

--- a/lib/hoodoo/presenters/types/hash.rb
+++ b/lib/hoodoo/presenters/types/hash.rb
@@ -58,9 +58,12 @@ module Hoodoo
         end
 
         @specific   = true
-        value_klass = block_given?               ?
-                      Hoodoo::Presenters::Object :
-                      type_option_to_class( options.delete( :type ) )
+
+        # If an explicit type is given, use that. Otherwise, default to Field
+        # if no block is given, or Object is a block is given.
+        #
+        value_klass = !options[:type].blank? ? type_option_to_class( options.delete( :type ) ) :
+                        (block_given? ? Hoodoo::Presenters::Object : Hoodoo::Presenters::Field)
 
         # If we're defining specific keys and some of those keys have fields
         # with defaults, we need to merge those up to provide a whole-Hash

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -12,11 +12,11 @@ module Hoodoo
   # The Hoodoo gem version. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.
   #
-  VERSION = '2.12.1'
+  VERSION = '2.12.2'
 
   # The Hoodoo gem date. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.
   #
-  DATE = '2019-02-22'
+  DATE = '2019-07-11'
 
 end

--- a/spec/presenters/types/hash_spec.rb
+++ b/spec/presenters/types/hash_spec.rb
@@ -680,7 +680,7 @@ describe Hoodoo::Presenters::Hash do
 
   ############################################################################
 
-  context 'specific key with a hash as ' do
+  context 'specific key with a hash as the type' do
     context '#render' do
       it 'renders required fields correctly' do
         input_data = { 'key_with_hash_type' => {


### PR DESCRIPTION
Fixes a bug in `Hoodoo::Presenters::Hash`. Previously, invoking the `key` method with a block would force the type to be `Hoodoo::Presenters::Object`, even when the type was set to `hash` (which may also accept a block). This would then break the nested schema in the block as Object does not support the `key`/`keys` methods.