### PR TITLE
Allow default permissions for Caller resource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,16 @@ sudo: false
 #
 cache: bundler
 
+# Fix for bundler 2.0 (which tries to exec the exact version listed in Gemfile.lock under BUNDLED WITH)
+# the travis test runner probably doesn't have this installed. We'll install it and rubygems 3.0+
+# see: https://bundler.io/v2.0/guides/bundler_2_upgrade.html
+before_install:
+  - gem update --system
+  - bundler_version=$(grep -A 1 "BUNDLED WITH" Gemfile.lock | sed -n 2p | tr -d ' ') && gem install bundler --version "${bundler_version}"
+  - gem --version
+  - gem list bundler
+
+
 addons:
   postgresql: "9.4" # (...or later)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hoodoo v2.x
 
+## 2.12.3 (2019-08-29)
+
+* Allow Caller resource to validate and render top-level default permissions.
+
 ## 2.12.2 (2019-07-11)
 
 * Support `hash` as a valid property type for keys.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    hoodoo (2.12.2)
+    hoodoo (2.12.3)
       dalli (~> 2.7)
       rack
 

--- a/lib/hoodoo/data/resources/caller.rb
+++ b/lib/hoodoo/data/resources/caller.rb
@@ -26,7 +26,7 @@ module Hoodoo
           end
 
           object :permissions, :required => true do
-            type :PermissionsResources, :required => true
+            type :PermissionsFull, :required => true
           end
 
           hash :scoping, :required => true do

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -12,11 +12,11 @@ module Hoodoo
   # The Hoodoo gem version. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.
   #
-  VERSION = '2.12.2'
+  VERSION = '2.12.3'
 
   # The Hoodoo gem date. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.
   #
-  DATE = '2019-07-11'
+  DATE = '2019-08-29'
 
 end

--- a/spec/data/resources/caller_spec.rb
+++ b/spec/data/resources/caller_spec.rb
@@ -80,6 +80,12 @@ describe Hoodoo::Data::Resources::Caller do
               },
               "else"    => "deny"
             }
+          },
+          "default" => {
+            "actions" => {
+              "show" => "allow"
+            },
+            "else"    => "deny"
           }
         },
         "scoping"    => {
@@ -116,6 +122,12 @@ describe Hoodoo::Data::Resources::Caller do
               },
               "else"    => "deny"
             }
+          },
+          "default" => {
+            "actions" => {
+              "show" => "allow"
+            },
+            "else"    => "deny"
           }
         },
         "scoping"    => {
@@ -148,7 +160,12 @@ describe Hoodoo::Data::Resources::Caller do
         'created_at'  => Hoodoo::Utilities.standard_datetime( created_at ),
         'kind'        => 'Caller',
         "identity"    => {},
-        "permissions" => { "resources" => {} },
+        "permissions" => {
+          "resources" => {},
+          "default"   => {
+            "else" => "deny"
+          }
+        },
         "scoping"     => {},
         "language"    => "en-nz"
       }


### PR DESCRIPTION
Currently, the Caller resource does not capture global defaults. For example, a superuser may want to default to `{ "else" => "allow" }` for all resources, or a monitor caller may need, list/show access to all resources. Currently, that requires maintaining a `resources` hash with the same permissions for each resource in your services. A better approach would be to be able to simply declare something like this:

```
"permissions" => {
  "default" => {
    "actions" => {
      "show" => "allow"
    }
  }
}
```

As a bonus, throwing in that workaround to get Travis to put up with our version of bundler.