### PR TITLE
DS-2034 Introduce guidelines about deploying a new release to RubyGems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,22 @@
-# Hoodoo v2.x
+# Hoodoo v3.x
+
+## 3.1.3 (2022-04-27)
+
+- Introduces guideline steps about how-to deploy a `Hoodoo` release to Rubygems [DS-2034](https://loyaltynz.atlassian.net/browse/DS-2034)
 
 ## 3.1.2 (2022-04-26)
 
-- Testing Hoodoo release [DS-2034](https://loyaltynz.atlassian.net/browse/DS-2034)
+- Testing `Hoodoo` release [DS-2034](https://loyaltynz.atlassian.net/browse/DS-2034)
 
 ## 3.1.1 (2022-04-19)
 
-- Tagging Hoodoo [DS-2034](https://loyaltynz.atlassian.net/browse/DS-2034)
+- Tagging `Hoodoo` [DS-2034](https://loyaltynz.atlassian.net/browse/DS-2034)
 
 ## 3.1.0 (2022-04-07)
 
 - Update ruby-version to 3.1.0 [DS-2034](https://loyaltynz.atlassian.net/browse/DS-2034)
-- Update bundler to 2.3.10
-- Update Rspec to 3.11
+- Update `Bundler` to 2.3.10
+- Update `Rspec` to 3.11
 - Update other general gems in patch level
 
 ## 3.0.1 (2022-02-16)
@@ -22,16 +26,18 @@
 ## 3.0.0 (2022-02-01)
 
 - Update ruby-version to 2.7.3
-- Update activerecord [DS-1484](https://loyaltynz.atlassian.net/browse/DS-1484)
+- Update `activerecord` [DS-1484](https://loyaltynz.atlassian.net/browse/DS-1484)
 - Removes support for ruby versions < 2.7.3
+
+# Hoodoo v2.x
 
 ## 2.12.11 (2021-11-30)
 
-- Update Postgres to version 13.3 [FT-811](https://loyaltynz.atlassian.net/browse/FT-811)
+- Update `Postgres` to version 13.3 [FT-811](https://loyaltynz.atlassian.net/browse/FT-811)
 
 ## 2.12.10 (2021-09-20)
 
-- Fix travis release to limit publishing build to a single ruby version.
+- Fix travis release to limit publishing build to a single `ruby` version.
 
 ## 2.12.9 (2021-09-07)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,40 @@ We love getting pull requests for new features or fixes!
 * Push the branch up (`git push origin feature/[description]`).
 * Create a pull request against `LoyaltyNZ/hoodoo` `master` branch describing what your change does and the why you think it should be merged.
 
+## RubyGems deployment
+In order to make Hoodoo Gem accessible to other Loyalty projects that are depending on it, new releases, internal releases,
+it is necessary to publish it in the central repository called RubyGems.
+
+The artifact submission process itself is coded in our CICD, implemented using Travis CI scripts. This specify CICD step is able to authenticate and send
+the new release without major difficulties, just following standard procedures. But the question that routinely needs some explanation and understanding
+here's how to trigger this process, to make it start.
+
+This trigger is based on the repository's refs, whenever a commit with a new tag is detected, the deploy step is triggered.
+
+Below is a brief description of the steps to reach this stage, from the code change, until we have a new version published on the RubyGems website.
+
+We imagine the scenario where we will increase the Hoodoo version, so this will be the recommended sequence of steps:
+
+1. Update version file, `lib/hoodoo/version.rb`, increasing constants VERSION and DATE
+2. Update Readme file itself, topic `Note`, to contain the expected upcoming version
+3. Run the command `bundle install`. Doing so, Bundle will be updating the file `Gemfile.lock` with the upcoming version
+4. Update the `CHANGELOG.md` file, to contain the upcoming version notes
+5. Start a new feature branch
+6. Commit changes
+7. Create a Pull Request
+8. Get approval for this Pull Request
+9. Merge the Pull Request
+10. Now comes the tricky part. Until now, wasn't asked to do any kind of tagging, which is ok. This step can be achieved using the proper GitHub UI, we just need to follow some very simple steps.
+    1. Access Hoodoo's repository home page, `https://github.com/LoyaltyNZ/hoodoo`
+    2. Then access the list of existent releases, clicking on `Releases` link (https://github.com/LoyaltyNZ/hoodoo/releases)
+    3. Now we need to start a Draft, clicking on `Draft a new release`
+    4. Type title and description
+    5. Click on `Choose a tag`, and copy over the entry from the changelog. Please do not select any existent tag, they do belong to older releases.
+    6. When all of this typing is done, click on the button `Publish release`
+11. When all these steps are done, just watch the CI process doing it's job. You can follow the steps accessing this page `https://app.travis-ci.com/github/LoyaltyNZ/hoodoo/builds/`
+12. When Travis CI finishes, then access `https://rubygems.org/gems/hoodoo` to see a new fresh release published.
+
+
 ## Guides
 
 We try to maintain the Hoodoo Guides internally but this is a big effort. If you're sending in a PR which might impact upon them, it would be really great if you could include an indication of this in your pull request description. Better still, if possible send us a related pull request to the `LoyaltyNZ/hoodoo` `gh-pages` branch which includes the necessary alterations!

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Some additional higher level hand written documentation may also be present as M
 - [Patrick Copeland](https://github.com/pjscopeland)
 - [Rory Stephenson](https://github.com/thelollies)
 - [Wayne Hoover](https://github.com/waynehoover)
+- [Ildomar Grings](https://github.com/ildomar-grings)
 
 ## Licence
 


### PR DESCRIPTION
Introduce a long explanation about how to deploy a new Gem release to Rubygems, using GitHub UI, Travis CI, and its triggers.