### PR TITLE
DS-2779 Update GEM Dalli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hoodoo v3.x
 
+## 3.1.7
+
+- Updated `dalli` from 2.x to 3.x, to fix security vulnerabilities. [DS-2779](https://loyaltynz.atlassian.net/browse/DS-2779)
+
 ## 3.1.6
 
 - Updated docs for 'downstream_error' added in v3.1.5 [FT-1114](https://loyaltynz.atlassian.net/browse/FT-1114)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     hoodoo (3.1.6)
-      dalli (~> 2.7)
+      dalli (>= 2.7, < 4.0)
       rack
 
 GEM
@@ -41,7 +41,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    dalli (2.7.11)
+    dalli (3.2.3)
     database_cleaner (1.99.0)
     diff-lcs (1.5.0)
     docile (1.4.0)

--- a/hoodoo.gemspec
+++ b/hoodoo.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do | s |
 
   s.required_ruby_version = '>= 3.1.0'
 
-  s.add_runtime_dependency     'dalli',            '~>  2.7' # Memcached client
+  s.add_runtime_dependency     'dalli',            '>= 2.7', '< 4.0' # Memcached client
   s.add_runtime_dependency     'rack'
 
   s.add_development_dependency 'activerecord',     '~>  7.0.1'


### PR DESCRIPTION
## Overview

[DS-2779](https://loyaltynz.atlassian.net/browse/DS-2779)

## What is the change?
- [x] Update GEM Dalli from `2.7.11` to `3.2.3` (https://github.com/LoyaltyNZ/hoodoo/pull/312)

## How was this change made?

## How do I use/reproduce this change?

## Notes

# Dalli 3.0


https://github.com/petergoldstein/dalli/edit/main/3.0-Upgrade.md

This major version update contains several backwards incompatible changes.

* **:dalli_store** has been removed. Users should migrate to the
  official Rails **:mem_cache_store**, documented in the [caching guide](https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-memcachestore).
- [x] FT repos, only `mrr` needs to be updated in the future. Currently using hoodoo (2.6.1)
![image](https://user-images.githubusercontent.com/98503264/205795158-aa8d91d8-19c8-4c14-946a-b9d2464a0e0e.png)
- [x] FT repos, others than that, other repos are relying on `Hoodoo::TransientStore::Base` storage types. The `dalli_store` type is not part of that list.

* Attempting to store a larger value than allowed by Memcached is used to
  print a warning and truncate the value. This now raises an error to
  prevent silent data corruption.
- [x] Hoodoo covers with `rescue => exception` for `save_to_store` and `load_from_store!` methods.

* Compression now defaults to `true` for large values (greater than 4KB).
  This is intended to minimize errors due to the previous note.
- [x] I see no risk 

* Errors marshaling values now raise rather than just printing an error.
- [x] Hoodoo covers with `rescue => exception` for `save_to_store` and `load_from_store!` methods.

* The Rack session adapter has been refactored to remove support for thread-unsafe
  configurations. You will need to include the `connection_pool` gem in
  your Gemfile to ensure session operations are thread-safe.
- [x] Hoodoo does not use `thread-unsafe`

* Support for the `kgio` gem has been removed, it is not relevant in Ruby 2.3+.
- [x] Hoodoo makes no use

* Removed inline native code, use Ruby 2.3+ support for bsearch instead.
- [x] Hoodoo currently requiring `s.required_ruby_version = '>= 3.1.0'`

* The CAS operations previously in 'dalli/cas/client' have been
  integrated into 'dalli/client'.
- [x] I see no risk 
