### PR TITLE
DS-2723: disallow Dalli 2.7.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hoodoo v3.x
 
+## 3.2.0
+
+- Updated `dalli` gem requirements to disallow 2.7.x. [DS-2723](https://loyaltynz.atlassian.net/browse/DS-2723)
+
 ## 3.1.7
 
 - Updated `dalli` from 2.x to 3.x, to fix security vulnerabilities. [DS-2779](https://loyaltynz.atlassian.net/browse/DS-2779)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,18 @@
 # Hoodoo v3.x
 
-## 3.2.0
+## 3.2.0 (2023-01-09)
 
 - Updated `dalli` gem requirements to disallow 2.7.x. [DS-2723](https://loyaltynz.atlassian.net/browse/DS-2723)
 
-## 3.1.7
+## 3.1.7 (2022-11-22)
 
 - Updated `dalli` from 2.x to 3.x, to fix security vulnerabilities. [DS-2779](https://loyaltynz.atlassian.net/browse/DS-2779)
 
-## 3.1.6
+## 3.1.6 (2022-10-04)
 
 - Updated docs for 'downstream_error' added in v3.1.5 [FT-1114](https://loyaltynz.atlassian.net/browse/FT-1114)
 
-## 3.1.5
+## 3.1.5 (2022-09-29)
 
 - Add 'downstream_error' to error_descriptions [FT-1114](https://loyaltynz.atlassian.net/browse/FT-1114)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    hoodoo (3.1.7)
-      dalli (>= 2.7, < 4.0)
+    hoodoo (3.2.0)
+      dalli (~> 3.2.3)
       rack
 
 GEM

--- a/hoodoo.gemspec
+++ b/hoodoo.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do | s |
 
   s.required_ruby_version = '>= 3.1.0'
 
-  s.add_runtime_dependency     'dalli',            '>= 2.7', '< 4.0' # Memcached client
+  s.add_runtime_dependency     'dalli',            '~> 3.2.3' # Memcached client
   s.add_runtime_dependency     'rack'
 
   s.add_development_dependency 'activerecord',     '~>  7.0.1'

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -12,7 +12,7 @@ module Hoodoo
   # The Hoodoo gem version. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.
   #
-  VERSION = '3.1.7'
+  VERSION = '3.2.0'
 
   # The Hoodoo gem date. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.


### PR DESCRIPTION
[DS-2723](https://loyaltynz.atlassian.net/browse/DS-2723)

Dalli 2.7.11 is the one mentioned in CVE-2022-4064, but the current version requirements don't stop any dependent projects using that version. For example service_fly_buys_purchase ([error](https://jenkins.loyaltydevops.co.nz/blue/organizations/jenkins/Kubernetes%2Fservice_fly_buys_purchase%2FPRCheck/detail/PRCheck/37/pipeline)):

![image](https://user-images.githubusercontent.com/48226990/211222058-e0d68ff6-2c9a-4924-b80c-abae9b1c49a9.png)

[DS-2723]: https://loyaltynz.atlassian.net/browse/DS-2723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ