### PR TITLE
DS-2987  Automated Monthly Patches - Feb23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Hoodoo v3.x
 
+## 3.2.2
+
+Automated Monthly Patching Feb23
+- Gems updated:
+  - dalli 3.2.4 (was 3.2.3)
+  - redis 4.8.1 (was 4.8.0)
+  - rspec-core 3.12.1 (was 3.12.0)
+  - tzinfo 2.0.6 (was 2.0.5)
+  - activesupport 7.0.4.2 (was 7.0.4.1)
+  - activemodel 7.0.4.2 (was 7.0.4.1)
+  - activerecord 7.0.4.2 (was 7.0.4.1)
+
 ## 3.2.1 (2023-01-19)
 
 - Monthly patches. [DS-2849](https://loyaltynz.atlassian.net/browse/DS-2849)
@@ -511,3 +523,4 @@ No functional changes; just some internal or documentation tweaks.
 ## 1.0.0, 1.0.1 (2015-12-10)
 
 Initial public release. Yanked as part of testing release processes, updating basic `hoodoo.gemspec` data and similar housekeeping.
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 PATH
   remote: .
   specs:
-    hoodoo (3.2.1)
+    hoodoo (3.2.2)
       dalli (~> 3.2.3)
       rack
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.4.1)
-      activesupport (= 7.0.4.1)
-    activerecord (7.0.4.1)
-      activemodel (= 7.0.4.1)
-      activesupport (= 7.0.4.1)
-    activesupport (7.0.4.1)
+    activemodel (7.0.4.2)
+      activesupport (= 7.0.4.2)
+    activerecord (7.0.4.2)
+      activemodel (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
+    activesupport (7.0.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -41,7 +41,7 @@ GEM
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    dalli (3.2.3)
+    dalli (3.2.4)
     database_cleaner (1.99.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
@@ -57,13 +57,13 @@ GEM
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (12.3.3)
-    redis (4.8.0)
+    redis (4.8.1)
     rexml (3.2.5)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.0)
+    rspec-core (3.12.1)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -82,7 +82,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     thor (1.2.1)
     timecop (0.9.6)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uuidtools (2.2.0)
     webmock (3.18.1)

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -12,7 +12,7 @@ module Hoodoo
   # The Hoodoo gem version. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.
   #
-  VERSION = '3.2.1'
+  VERSION = '3.2.2'
 
   # The Hoodoo gem date. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.


### PR DESCRIPTION
# Automated Monthly Patches
**Base Image:** docker.loyaltydevops.co.nz/service_base_ruby:3.1.0
**Command used:** # bundle update --patch
**Jenkins build:** https://jenkins.loyaltydevops.co.nz/job/TechOps/job/cron-jobs/job/PatchBot/job/bundle_update_dryrun/47/



## Changes:
- dalli 3.2.4 (was 3.2.3)
- redis 4.8.1 (was 4.8.0)
- rspec-core 3.12.1 (was 3.12.0)
- tzinfo 2.0.6 (was 2.0.5)
- activesupport 7.0.4.2 (was 7.0.4.1)
- activemodel 7.0.4.2 (was 7.0.4.1)
- activerecord 7.0.4.2 (was 7.0.4.1)
