### PR TITLE
DS-3525 Support older (3.1.2) versions of ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os: linux
 dist: focal
 
 rvm:
+  - 3.1.2
   - 3.2.2
 
 # http://docs.travis-ci.com/user/caching/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hoodoo v3.x
 
+## 3.3.1
+
+- Support ruby `3.1.2` - [DS-3525](https://loyaltynz.atlassian.net/browse/DS-3525)
+
 ## 3.3.0
 
 - Replace gem `le` with `r7insight` - [DS-3525](https://loyaltynz.atlassian.net/browse/DS-3525)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hoodoo (3.3.0)
+    hoodoo (3.3.1)
       dalli (~> 3.2.3)
       rack
 

--- a/hoodoo.gemspec
+++ b/hoodoo.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do | s |
   s.test_files  = Dir.glob( 'spec/**/*.rb' )
   s.homepage    = 'https://loyaltynz.github.io/hoodoo/'
 
-  s.required_ruby_version = '>= 3.2'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_runtime_dependency     'dalli',            '~> 3.2.3' # Memcached client
   s.add_runtime_dependency     'rack'

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -12,11 +12,11 @@ module Hoodoo
   # The Hoodoo gem version. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.
   #
-  VERSION = '3.3.0'
+  VERSION = '3.3.1'
 
   # The Hoodoo gem date. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.
   #
-  DATE = '2023-07-31'
+  DATE = '2023-08-11'
 
 end


### PR DESCRIPTION
## Overview

[DS-3525](https://loyaltynz.atlassian.net/browse/DS-3525)

## What is the change?

- Support projects that use ruby `3.1.2`

## How was this change made?

## How do I use/reproduce this change?

## Notes

[DS-3525]: https://loyaltynz.atlassian.net/browse/DS-3525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ