### PR TITLE
FT-4004 Updated Caller, added authentication_secret_parameter_store_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hoodoo v3.x
 
+## 3.5.0
+
+- Updated `Caller` resource schema, added `authentication_secret_parameter_store_path` - [FT-4004](https://loyaltynz.atlassian.net/browse/FT-4004)
+
 ## 3.4.3
 
 Automated Monthly Patching Jan24

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hoodoo (3.4.3)
+    hoodoo (3.5.0)
       dalli (~> 3.2.3)
       ddtrace (~> 1.0)
       rack

--- a/lib/hoodoo/data/resources/caller.rb
+++ b/lib/hoodoo/data/resources/caller.rb
@@ -19,6 +19,7 @@ module Hoodoo
           internationalised
 
           text :authentication_secret
+          text :authentication_secret_parameter_store_path, :required => false
           text :name
           uuid :fingerprint, :required => false
 

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -12,11 +12,11 @@ module Hoodoo
   # The Hoodoo gem version. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.
   #
-  VERSION = '3.4.3'
+  VERSION = '3.5.0'
 
   # The Hoodoo gem date. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.
   #
-  DATE = '2023-08-16'
+  DATE = '2024-01-25'
 
 end

--- a/spec/data/resources/caller_spec.rb
+++ b/spec/data/resources/caller_spec.rb
@@ -9,6 +9,7 @@ describe Hoodoo::Data::Resources::Caller do
     expect(schema.properties.count).to eq(6)
 
     expect(schema.properties['authentication_secret']).to be_a(Hoodoo::Presenters::Text)
+    expect(schema.properties['authentication_secret_parameter_store_path']).to be_a(Hoodoo::Presenters::Text)
     expect(schema.properties['name']).to be_a(Hoodoo::Presenters::Text)
     expect(schema.properties['fingerprint']).to be_a(Hoodoo::Presenters::UUID)
     expect(schema.properties['identity']).to be_a(Hoodoo::Presenters::Hash)
@@ -63,6 +64,7 @@ describe Hoodoo::Data::Resources::Caller do
     json       = described_class.render(
       {
         "name"       => "Test Caller",
+        "authentication_secret_parameter_store_path" => "/path/to/secret",
         "identity"   => {
           "array"   => [],
           "integer" => 1,
@@ -99,6 +101,7 @@ describe Hoodoo::Data::Resources::Caller do
         'created_at' => Hoodoo::Utilities.standard_datetime( created_at ),
         'kind'       => 'Caller',
         "name"       => "Test Caller",
+        "authentication_secret_parameter_store_path" => "/path/to/secret",
         "identity"   => {
           "array"   => [],
           "integer" => 1,
@@ -136,7 +139,8 @@ describe Hoodoo::Data::Resources::Caller do
       {
         "identity"    => {},
         "permissions" => { "resources" => {} },
-        "scoping"     => {}
+        "scoping"     => {},
+        "authentication_secret_parameter_store_path" => "/path/to/secret"
       },
       id,
       created_at
@@ -150,7 +154,8 @@ describe Hoodoo::Data::Resources::Caller do
         "identity"    => {},
         "permissions" => { "resources" => {} },
         "scoping"     => {},
-        "language"    => "en-nz"
+        "language"    => "en-nz",
+        "authentication_secret_parameter_store_path" => "/path/to/secret"
       }
     )
   end

--- a/spec/data/resources/caller_spec.rb
+++ b/spec/data/resources/caller_spec.rb
@@ -139,8 +139,7 @@ describe Hoodoo::Data::Resources::Caller do
       {
         "identity"    => {},
         "permissions" => { "resources" => {} },
-        "scoping"     => {},
-        "authentication_secret_parameter_store_path" => "/path/to/secret"
+        "scoping"     => {}
       },
       id,
       created_at
@@ -154,8 +153,7 @@ describe Hoodoo::Data::Resources::Caller do
         "identity"    => {},
         "permissions" => { "resources" => {} },
         "scoping"     => {},
-        "language"    => "en-nz",
-        "authentication_secret_parameter_store_path" => "/path/to/secret"
+        "language"    => "en-nz"
       }
     )
   end

--- a/spec/data/resources/caller_spec.rb
+++ b/spec/data/resources/caller_spec.rb
@@ -6,7 +6,7 @@ describe Hoodoo::Data::Resources::Caller do
 
     expect(schema.is_internationalised?()).to eq(true)
 
-    expect(schema.properties.count).to eq(6)
+    expect(schema.properties.count).to eq(7)
 
     expect(schema.properties['authentication_secret']).to be_a(Hoodoo::Presenters::Text)
     expect(schema.properties['authentication_secret_parameter_store_path']).to be_a(Hoodoo::Presenters::Text)


### PR DESCRIPTION
## Overview

[FT-4004](https://loyaltynz.atlassian.net/browse/FT-4004)

## What is the change?

Updated the `Caller` schema, added new attribute `authentication_secret_parameter_store_path` - see https://github.com/LoyaltyNZ/awg/pull/814.

Note this is backwards compatible, the new attribute is only rendered if data is supplied for it

## How was this change made?

Updated the schema and associated tests

## How do I use/reproduce this change?

## Notes

[FT-4004]: https://loyaltynz.atlassian.net/browse/FT-4004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ