### PR TITLE
DS-4332  Automated Monthly Patches - Mar24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Hoodoo v3.x
 
+## 3.5.5
+
+Automated Monthly Patching Mar24
+- Gems updated:
+  - bigdecimal 3.1.7 (was 3.1.6) with native extensions
+  - rack 2.2.9 (was 2.2.8.1)
+  - i18n 1.14.4 (was 1.14.1)
+  - rdoc 6.5.1.1 (was 6.5.0)
+
 ## 3.5.4
 
 Automated Monthly Patching Mar24

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     amqp (1.8.0)
       amq-protocol (>= 2.2.0)
       eventmachine
-    bigdecimal (3.1.6)
+    bigdecimal (3.1.7)
     bundle-audit (0.1.0)
       bundler-audit
     bundler-audit (0.9.1)
@@ -64,7 +64,7 @@ GEM
     eventmachine (1.2.7)
     ffi (1.16.3)
     hashdiff (1.0.1)
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
     irb (1.8.3)
@@ -81,11 +81,11 @@ GEM
       stringio
     public_suffix (5.0.4)
     r7insight (3.0.4)
-    rack (2.2.8.1)
+    rack (2.2.9)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (12.3.3)
-    rdoc (6.5.0)
+    rdoc (6.5.1.1)
       psych (>= 4.0.0)
     redis (4.8.1)
     reline (0.3.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hoodoo (3.5.5)
+    hoodoo (3.5.6)
       bigdecimal
       dalli (~> 3.2.3)
       ddtrace (~> 1.0)

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -12,7 +12,7 @@ module Hoodoo
   # The Hoodoo gem version. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.
   #
-  VERSION = '3.5.4'
+  VERSION = '3.5.5'
 
   # The Hoodoo gem date. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -12,7 +12,7 @@ module Hoodoo
   # The Hoodoo gem version. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.
   #
-  VERSION = '3.5.5'
+  VERSION = '3.5.6'
 
   # The Hoodoo gem date. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.


### PR DESCRIPTION
# Automated Monthly Patches
**Base Image:** docker.loyaltydevops.co.nz/service_base_ruby:3.3.0
**Command used:** # bundle update --patch
**Jenkins build:** https://jenkins.loyaltydevops.co.nz/job/TechOps/job/cron-jobs/job/MonthlyPatching/job/bundle_update/1245/



## Changes:
- bigdecimal 3.1.7 (was 3.1.6) with native extensions
- rack 2.2.9 (was 2.2.8.1)
- i18n 1.14.4 (was 1.14.1)
- rdoc 6.5.1.1 (was 6.5.0)
