### PR TITLE
DS-4649  Automated Monthly Patches - Jun24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Hoodoo v3.x
 
+## 3.5.8
+
+Automated Monthly Patching Jun24
+- Gems updated:
+  - bigdecimal 3.1.8 (was 3.1.7) with native extensions
+  - timecop 0.9.9 (was 0.9.8)
+  - i18n 1.14.5 (was 1.14.4)
+  - rexml 3.2.8 (was 3.2.6)
+  - activesupport 7.0.8.3 (was 7.0.8.1)
+  - activemodel 7.0.8.3 (was 7.0.8.1)
+  - activerecord 7.0.8.3 (was 7.0.8.1)
+
 ## 3.5.7
 
 Automated Monthly Patching May24

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hoodoo (3.5.7)
+    hoodoo (3.5.8)
       bigdecimal
       dalli (~> 3.2.3)
       ddtrace (~> 1.0)
@@ -12,12 +12,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.8.1)
-      activesupport (= 7.0.8.1)
-    activerecord (7.0.8.1)
-      activemodel (= 7.0.8.1)
-      activesupport (= 7.0.8.1)
-    activesupport (7.0.8.1)
+    activemodel (7.0.8.3)
+      activesupport (= 7.0.8.3)
+    activerecord (7.0.8.3)
+      activemodel (= 7.0.8.3)
+      activesupport (= 7.0.8.3)
+    activesupport (7.0.8.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -36,7 +36,7 @@ GEM
     amqp (1.8.0)
       amq-protocol (>= 2.2.0)
       eventmachine
-    bigdecimal (3.1.7)
+    bigdecimal (3.1.8)
     bundle-audit (0.1.0)
       bundler-audit
     bundler-audit (0.9.1)
@@ -64,7 +64,7 @@ GEM
     eventmachine (1.2.7)
     ffi (1.16.3)
     hashdiff (1.0.1)
-    i18n (1.14.4)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
     irb (1.8.3)
@@ -90,7 +90,8 @@ GEM
     redis (4.8.1)
     reline (0.3.9)
       io-console (~> 0.5)
-    rexml (3.2.6)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -113,8 +114,9 @@ GEM
       simplecov (>= 0.4.1)
     simplecov_json_formatter (0.1.4)
     stringio (3.1.0)
+    strscan (3.1.0)
     thor (1.2.2)
-    timecop (0.9.8)
+    timecop (0.9.9)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uuidtools (2.2.0)

--- a/lib/hoodoo/version.rb
+++ b/lib/hoodoo/version.rb
@@ -12,7 +12,7 @@ module Hoodoo
   # The Hoodoo gem version. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.
   #
-  VERSION = '3.5.7'
+  VERSION = '3.5.8'
 
   # The Hoodoo gem date. If this changes, be sure to re-run
   # <tt>bundle install</tt> or <tt>bundle update</tt>.


### PR DESCRIPTION
# Automated Monthly Patches
**Base Image:** docker.loyaltydevops.co.nz/service_base_ruby:3.3.0
**Command used:** # bundle update --patch
**Jenkins build:** https://jenkins.loyaltydevops.co.nz/job/TechOps/job/cron-jobs/job/MonthlyPatching/job/bundle_update/1357/



## Changes:
- bigdecimal 3.1.8 (was 3.1.7) with native extensions
- timecop 0.9.9 (was 0.9.8)
- i18n 1.14.5 (was 1.14.4)
- rexml 3.2.8 (was 3.2.6)
- activesupport 7.0.8.3 (was 7.0.8.1)
- activemodel 7.0.8.3 (was 7.0.8.1)
- activerecord 7.0.8.3 (was 7.0.8.1)
